### PR TITLE
Issue 15: Fix duplicate write-lock and entity create/destroy operations

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/IMessageSenderWrapper.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/IMessageSenderWrapper.java
@@ -35,4 +35,12 @@ public interface IMessageSenderWrapper {
    * NOTE:  This can only be used for identity-matching purposes (could be replaced with a client-unique ID, later on).
    */
   PassthroughConnection getClientOrigin();
+  /**
+   * Note that this is a temporary work-around to test re-sent create/destroy messages which the server can't ignore as
+   * duplicated.
+   * XXX: This should be replaced with precise transaction order persistence with special tracking for these internal
+   * messages which must be ignored as duplicated.
+   * @return True if create or destroy messages which may to be duplicated should be treated as successes.
+   */
+  boolean shouldTolerateCreateDestroyDuplication();
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnectionState.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnectionState.java
@@ -70,7 +70,8 @@ public class PassthroughConnectionState {
     }
     byte[] raw = message.asSerializedBytes();
     waiter.saveRawMessageForResend(raw);
-    target.sendMessageToServer(sender, raw);
+    boolean isResend = false;
+    target.sendMessageToServer(sender, raw, isResend);
     return waiter;
   }
 
@@ -102,7 +103,8 @@ public class PassthroughConnectionState {
     Assert.assertTrue(null != this.reconnectingServerProcess);
     byte[] raw = waiter.resetAndGetMessageForResend();
     this.reconnectingInFlightMessages.put(transactionID, waiter);
-    this.reconnectingServerProcess.sendMessageToServer(sender, raw);
+    boolean isResend = true;
+    this.reconnectingServerProcess.sendMessageToServer(sender, raw, isResend);
   }
 
   public synchronized PassthroughWait getWaiterForTransaction(PassthroughServerProcess sender, long transactionID) {

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityRef.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityRef.java
@@ -143,6 +143,9 @@ public class PassthroughEntityRef<T extends Entity, C> implements EntityRef<T, C
     PassthroughMessage lockMessage = PassthroughMessageCodec.createWriteLockAcquireMessage(this.clazz, this.name);
     try {
       this.passthroughConnection.sendInternalMessageAfterAcks(lockMessage).get();
+      // Notify the connection that we have this write lock since it will need it if we reconnect.
+      PassthroughEntityTuple entityTuple = new PassthroughEntityTuple(this.clazz.getCanonicalName(), this.name);
+      this.passthroughConnection.didAcquireWriteLock(entityTuple);
     } catch (InterruptedException e) {
       Assert.unexpected(e);
     } catch (EntityException e) {
@@ -154,6 +157,9 @@ public class PassthroughEntityRef<T extends Entity, C> implements EntityRef<T, C
     PassthroughMessage lockMessage = PassthroughMessageCodec.createWriteLockReleaseMessage(this.clazz, this.name);
     try {
       this.passthroughConnection.sendInternalMessageAfterAcks(lockMessage).get();
+      // Notify the connection that we released this write lock so it isn't requested on reconnect.
+      PassthroughEntityTuple entityTuple = new PassthroughEntityTuple(this.clazz.getCanonicalName(), this.name);
+      this.passthroughConnection.didReleaseWriteLock(entityTuple);
     } catch (InterruptedException e) {
       Assert.unexpected(e);
     } catch (EntityException e) {

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityTuple.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityTuple.java
@@ -22,10 +22,11 @@ package org.terracotta.passthrough;
 /**
  * Contains the data required to uniquely identify an entity ref (either an entity or where an entity can be created).
  * Contains the class name and entity name.
+ * The data members are public and final since this is meant to be used as an immutable struct.
  */
 public class PassthroughEntityTuple {
-  private final String entityClassName;
-  private final String entityName;
+  public final String entityClassName;
+  public final String entityName;
 
   public PassthroughEntityTuple(String entityClassName, String entityName) {
     this.entityClassName = entityClassName;

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughInterserverInterlock.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughInterserverInterlock.java
@@ -57,4 +57,9 @@ public class PassthroughInterserverInterlock implements IMessageSenderWrapper {
   public PassthroughConnection getClientOrigin() {
     return sender.getClientOrigin();
   }
+  @Override
+  public boolean shouldTolerateCreateDestroyDuplication() {
+    // We will use whatever the underlying sender thinks.
+    return sender.shouldTolerateCreateDestroyDuplication();
+  }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessage.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessage.java
@@ -40,6 +40,7 @@ public abstract class PassthroughMessage {
     INVOKE_ON_CLIENT,
     LOCK_ACQUIRE,
     LOCK_RELEASE,
+    LOCK_RESTORE,
     RECONNECT,
     SYNC_ENTITY_START,
     SYNC_ENTITY_END,

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
@@ -152,8 +152,8 @@ public class PassthroughMessageCodec {
   }
 
   public static PassthroughMessage createWriteLockAcquireMessage(final Class<?> entityClass, final String entityName) {
-    // Lock-state must be preserved on passive.
-    boolean shouldReplicateToPassives = true;
+    // Lock-state is just an interaction between client and server which must be cleanly rebuilt on reconnect so don't replicate.
+    boolean shouldReplicateToPassives = false;
     return new PassthroughMessage(Type.LOCK_ACQUIRE, shouldReplicateToPassives) {
       @Override
       protected void populateStream(DataOutputStream output) throws IOException {
@@ -163,12 +163,23 @@ public class PassthroughMessageCodec {
   }
 
   public static PassthroughMessage createWriteLockReleaseMessage(final Class<?> entityClass, final String entityName) {
-    // Lock-state must be preserved on passive.
-    boolean shouldReplicateToPassives = true;
+    // Lock-state is just an interaction between client and server which must be cleanly rebuilt on reconnect so don't replicate.
+    boolean shouldReplicateToPassives = false;
     return new PassthroughMessage(Type.LOCK_RELEASE, shouldReplicateToPassives) {
       @Override
       protected void populateStream(DataOutputStream output) throws IOException {
         output.writeUTF(entityClass.getCanonicalName());
+        output.writeUTF(entityName);
+      }};
+  }
+
+  public static PassthroughMessage createWriteLockRestoreMessage(final String entityClassName, final String entityName) {
+    // Lock-state is just an interaction between client and server which must be cleanly rebuilt on reconnect so don't replicate.
+    boolean shouldReplicateToPassives = false;
+    return new PassthroughMessage(Type.LOCK_RESTORE, shouldReplicateToPassives) {
+      @Override
+      protected void populateStream(DataOutputStream output) throws IOException {
+        output.writeUTF(entityClassName);
         output.writeUTF(entityName);
       }};
   }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerMessageDecoder.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerMessageDecoder.java
@@ -192,6 +192,31 @@ public class PassthroughServerMessageDecoder implements PassthroughMessageCodec.
         sendCompleteResponse(sender, transactionID, response, error);
         break;
       }
+      case LOCK_RESTORE: {
+        // This is called to reestablish a maintenance write-lock on reconnect.
+        // It only has the class and entity name for the locked entity.
+        String entityClassName = input.readUTF();
+        String entityName = input.readUTF();
+        Runnable onAcquire = new Runnable() {
+          @Override
+          public void run() {
+            // We will just send an empty response, with no error, on restore.
+            byte[] response = new byte[0];
+            Exception error = null;
+            sendCompleteResponse(sender, transactionID, response, error);
+          }
+        };
+        try {
+          // We still use the same "onAcquire" runnable approach used by the other methods, just for consistency, since this
+          // call can't fail or block.  Success is REQUIRED since we are only receiving this on reconnect of a client which
+          // already knew that it had the lock so a disagreement here would mean that there is a serious bug.
+          this.messageHandler.restoreWriteLock(sender, entityClassName, entityName, onAcquire);
+        } catch (Exception error) {
+          // An unexpected exception is the only case where we send the response at this level.
+          sendCompleteResponse(sender, transactionID, null, error);
+        }
+        break;
+      }
       case RECONNECT: {
         String entityClassName = input.readUTF();
         String entityName = input.readUTF();
@@ -319,6 +344,7 @@ public class PassthroughServerMessageDecoder implements PassthroughMessageCodec.
     byte[] invoke(IMessageSenderWrapper sender, long clientInstanceID, String entityClassName, String entityName, byte[] payload) throws Exception;
     void acquireWriteLock(IMessageSenderWrapper sender, String entityClassName, String entityName, Runnable onAcquire);
     void releaseWriteLock(IMessageSenderWrapper sender, String entityClassName, String entityName);
+    void restoreWriteLock(IMessageSenderWrapper sender, String entityClassName, String entityName, Runnable onAcquire);
     void reconnect(IMessageSenderWrapper sender, long clientInstanceID, String entityClassName, String entityName, byte[] extendedData);
     void syncEntityStart(IMessageSenderWrapper sender, String entityClassName, String entityName) throws Exception;
     void syncEntityEnd(IMessageSenderWrapper sender, String entityClassName, String entityName) throws Exception;

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerMessageDecoder.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerMessageDecoder.java
@@ -71,7 +71,13 @@ public class PassthroughServerMessageDecoder implements PassthroughMessageCodec.
           // There is no response on successful create.
           this.messageHandler.create(entityClassName, entityName, version, serializedConfiguration);
         } catch (Exception e) {
-          error = e;
+          // We may want to ignore this failure on re-send.
+          if (sender.shouldTolerateCreateDestroyDuplication()) {
+            // Absorb the error.
+          } else {
+            // Real error.
+            error = e;
+          }
         }
         sendCompleteResponse(sender, transactionID, response, error);
         break;
@@ -85,7 +91,13 @@ public class PassthroughServerMessageDecoder implements PassthroughMessageCodec.
           // There is no response on successful delete.
           this.messageHandler.destroy(entityClassName, entityName);
         } catch (Exception e) {
-          error = e;
+          // We may want to ignore this failure on re-send.
+          if (sender.shouldTolerateCreateDestroyDuplication()) {
+            // Absorb the error.
+          } else {
+            // Real error.
+            error = e;
+          }
         }
         sendCompleteResponse(sender, transactionID, response, error);
         break;

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -413,6 +413,12 @@ public class PassthroughServerProcess implements MessageHandler {
   }
 
   @Override
+  public void restoreWriteLock(IMessageSenderWrapper sender, String entityClassName, String entityName, Runnable onAcquire) {
+    PassthroughEntityTuple entityTuple = new PassthroughEntityTuple(entityClassName, entityName);
+    this.lockManager.restoreWriteLock(entityTuple, sender.getClientOrigin(), onAcquire);
+  }
+
+  @Override
   public void reconnect(final IMessageSenderWrapper sender, final long clientInstanceID, final String entityClassName, final String entityName, final byte[] extendedData) {
     final PassthroughEntityTuple entityTuple = new PassthroughEntityTuple(entityClassName, entityName);
     

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -194,7 +194,7 @@ public class PassthroughServerProcess implements MessageHandler {
     this.serverThread = null;
   }
 
-  public synchronized void sendMessageToServer(final PassthroughConnection sender, byte[] message) {
+  public synchronized void sendMessageToServer(final PassthroughConnection sender, byte[] message, final boolean isResend) {
     Assert.assertTrue(this.isRunning);
     MessageContainer container = new MessageContainer();
     container.sender = new IMessageSenderWrapper() {
@@ -213,6 +213,11 @@ public class PassthroughServerProcess implements MessageHandler {
       @Override
       public PassthroughConnection getClientOrigin() {
         return sender;
+      }
+      @Override
+      public boolean shouldTolerateCreateDestroyDuplication() {
+        // We will handle this if the message is re-sent.
+        return isResend;
       }
     };
     container.message = message;


### PR DESCRIPTION
Note that the work-around for duplicate create/destroy calls is only temporary and will be resolved, more completely, under #16.