### PR TITLE
Fix #18: Use EntityException, instead of Exception, through more of t…

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/IFetchResult.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/IFetchResult.java
@@ -18,11 +18,13 @@
  */
 package org.terracotta.passthrough;
 
+import org.terracotta.exception.EntityException;
+
 
 /**
  * Defines the callback invoked on successful resolution of a fetch message.  The reason why we need a callback and not a
  * simple call-return structure is that the fetch may block on lock acquisition.
  */
 public interface IFetchResult {
-  public void onFetchComplete(byte[] config, Exception error);
+  public void onFetchComplete(byte[] config, EntityException error);
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
@@ -116,7 +116,7 @@ public class PassthroughMessageCodec {
       }};
   }
 
-  public static PassthroughMessage createCompleteMessage(final byte[] response, final Exception error) {
+  public static PassthroughMessage createCompleteMessage(final byte[] response, final EntityException error) {
     // Replication ignored in this context.
     boolean shouldReplicateToPassives = false;
     return new PassthroughMessage(Type.COMPLETE_FROM_SERVER, shouldReplicateToPassives) {
@@ -132,7 +132,7 @@ public class PassthroughMessageCodec {
             output.writeInt(-1);
           }
         } else {
-          byte[] serializedException = PassthroughMessageCodec.serializeObjectToArray(error);
+          byte[] serializedException = PassthroughMessageCodec.serializeExceptionToArray(error);
           output.writeInt(serializedException.length);
           output.write(serializedException);
         }
@@ -291,7 +291,7 @@ public class PassthroughMessageCodec {
     return runRawDecoder(decoder, rawMessage);
   }
   
-  public static byte[] serializeObjectToArray(Exception exception) {
+  public static byte[] serializeExceptionToArray(EntityException exception) {
     // We need to manually serialize the exception using Java serialization.
     ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
     try {


### PR DESCRIPTION
…he internals and codec

-this starts with the change to make PassthroughMessageCodec's exception serialization symmetric but it allowed for a tightening of exception use-cases, elsewhere
-of key interest is the change to PassthroughServerMessageDecoder.MessageHandler's method signatures to throw EntityException, instead of Exception.  This means that more specific exceptions must be thrown from within the implementation, at the point where that knowledge is available.  The caller then catches RuntimeException to wrap anything else that slips through the cracks in an EntityUserException
-for the most part, this meant throwing EntityNotFoundException, instead of Exception, when an entity failed to be resolved