### PR TITLE
Fix #21: Added the basic interfaces and helpers to build tests on the passthrough classes

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/IClusterControl.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/IClusterControl.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import org.terracotta.connection.Connection;
+
+
+/**
+ * Exposes methods to control or wait for servers within the cluster being tested.
+ * It is provided as a generic interface, not specifically coupled to the passthrough classes, so that other test harnesses
+ * can provide implementations in order to generalize test code for in-process or multi-process implementations.
+ */
+public interface IClusterControl {
+  /**
+   * Restarts the active server in the cluster.
+   * 
+   * @throws Exception A failure in the restart, defined by the implementation.
+   */
+  public void restartActive() throws Exception;
+
+  /**
+   * Waits for the active server in the cluster to come online and determine that it is active.
+   * 
+   * @throws Exception A failure waiting, defined by the implementation.
+   */
+  public void waitForActive() throws Exception;
+
+  /**
+   * Waits for the active server in the cluster to come online and determine that it is passive.
+   * 
+   * @throws Exception A failure waiting, defined by the implementation.
+   */
+  public void waitForPassive() throws Exception;
+
+  /**
+   * Creates a new connection to the active in the cluster.
+   * 
+   * @return The Connection on which operations can now be performed.
+   */
+  public Connection createConnectionToActive();
+
+  /**
+   * Shuts down the cluster, rendering any further calls on the receiver or any Connections undefined.
+   */
+  public void tearDown();
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/ICommonTest.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/ICommonTest.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import org.terracotta.connection.Connection;
+
+
+/**
+ * This interface describes the common shape the user code within a single system test.
+ * It exists to allow test implementations to be passed around, abstractly, by test harnesses.
+ * NOTE:  The tests, themselves, are expected to be state-less as they may be accessed concurrently by different threads or
+ * processes.
+ */
+public interface ICommonTest {
+  /**
+   * Called at the beginning of a test run, by a single thread or process, to prepare the server state for the test before
+   * multiple threads or processes are started to run it.
+   */
+  public void runSetup(Connection connection);
+
+  /**
+   * Called at the end of a test run, by a single thread or process, to clean up the server state now that the test has
+   * completed.
+   */
+  public void runDestroy(Connection connection);
+
+  /**
+   * Runs the actual test.  Note that this call is expected to have no side-effects within the receiver, as it may be called
+   * by multiple threads or processes, concurrently.
+   * The control or connection are the only ways side-effects should be realized (as the test obviously needs to interact
+   * with the server and may way to control the cluster).
+   */
+  public void runTest(IClusterControl control, Connection connection) throws Throwable;
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughClusterControl.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughClusterControl.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import org.terracotta.connection.Connection;
+
+
+/**
+ * The implementation used to control the passthrough testing cluster.
+ */
+public class PassthroughClusterControl implements IClusterControl {
+  // We track the "original" server state for tear-down.
+  private final PassthroughServer originalActiveServer;
+  private final PassthroughServer originalPassiveServer;
+
+  // The active we are currently using can change on restart.
+  private PassthroughServer activeServer;
+
+  public PassthroughClusterControl(PassthroughServer activeServer, PassthroughServer passiveServer) {
+    // The active cannot be null but the passive can be.
+    Assert.assertTrue(null != activeServer);
+    this.originalActiveServer = activeServer;
+    this.originalPassiveServer = passiveServer;
+    // We set the changing active server to be the original.
+    this.activeServer = activeServer;
+  }
+
+  @Override
+  public void restartActive() throws Exception {
+    this.activeServer = this.activeServer.restart();
+  }
+
+  @Override
+  public void waitForActive() throws Exception {
+    // Do nothing - the restart brings up the active, immediately.
+  }
+
+  @Override
+  public void waitForPassive() throws Exception {
+    // Do nothing - the restart brings up the active, immediately.
+  }
+
+  @Override
+  public Connection createConnectionToActive() {
+    return this.activeServer.connectNewClient();
+  }
+
+  @Override
+  public void tearDown() {
+    this.originalActiveServer.stop();
+    if (null != this.originalPassiveServer) {
+      this.originalPassiveServer.stop();
+    }
+  }
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTestHelpers.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTestHelpers.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+
+/**
+ * Used for setting up IClusterControl instances to wrap test cluster configurations, based on the passthrough classes.
+ * It describes a single stripe, consisting of a single active and an optional passive.  Services for providing server-side
+ * functionality, server-side entities, or client-side entities, are registered via the given ServerInitializer callback,
+ * allowing common initialization code to be invoked on each server in the stripe.
+ * It can be used by arbitrary testing systems as it acts as a library, not a framework.
+ */
+public class PassthroughTestHelpers {
+  /**
+   * Creates a cluster consisting only of a single server in active state.
+   * 
+   * @param initializer The callback to handle initialization of the server.
+   * @return A control object to use for interacting with the cluster.
+   */
+  public static IClusterControl createActiveOnly(ServerInitializer initializer) {
+    boolean activeMode = true;
+    PassthroughServer activeServer = intializeOneServer(initializer, activeMode);
+    PassthroughServer passiveServer = null;
+    return new PassthroughClusterControl(activeServer, passiveServer);
+  }
+
+  /**
+   * Creates a cluster consisting only of 2 servers configured as 1 stripe:  an active and a passive.
+   * 
+   * @param initializer The callback to handle initialization of both servers, called on each.
+   * @return A control object to use for interacting with the cluster.
+   */
+  public static IClusterControl createActivePassive(ServerInitializer initializer) {
+    boolean activeMode = true;
+    PassthroughServer activeServer = intializeOneServer(initializer, activeMode);
+    PassthroughServer passiveServer = intializeOneServer(initializer, !activeMode);
+    activeServer.attachDownstreamPassive(passiveServer);
+    return new PassthroughClusterControl(activeServer, passiveServer);
+  }
+
+  private static PassthroughServer intializeOneServer(ServerInitializer initializer, boolean activeMode) {
+    PassthroughServer activeServer = new PassthroughServer(activeMode);
+    initializer.registerServicesForServer(activeServer);
+    activeServer.start();
+    return activeServer;
+  }
+
+
+  /**
+   * In order to register any service providers, client-side and server-side entity provider services, an implementation of
+   * this interface is used.
+   * These cannot be set directly on the harness as each server in the stripe is expected to have its own provider instances.
+   * This interface acts as a callback for when one of the servers on the stripe is about to be made active, so that it can
+   * have those providers registered.  This also means that the implementation should be state-less, acting only on the
+   * server instance it is given.
+   */
+  public interface ServerInitializer {
+    public void registerServicesForServer(PassthroughServer server);
+  }
+}


### PR DESCRIPTION
-IClusterControl defines how to interact with a stripe from inside a test
-ICommonTest defines a simple yet effective test shape - setup and destroy are done by an over-arching thread or process while the test is run by on potentially different (potentially many) clients
-PassthroughClusterControl is an implementation of IClusterControl to expose the control of a testing stripe built on the passthrough classes
-PassthroughTestHelpers contains some basic helpers for common testing cluster topology setup