### PR TITLE
Fix #27: Added tryDestroy to EntityRef API

### DIFF
--- a/connection-api/src/main/java/org/terracotta/connection/entity/EntityRef.java
+++ b/connection-api/src/main/java/org/terracotta/connection/entity/EntityRef.java
@@ -57,6 +57,17 @@ public interface EntityRef<T extends Entity, C> {
   void destroy() throws EntityNotProvidedException, EntityNotFoundException;
 
   /**
+   * Destroy the entity pointed to by this reference, but only if there are no open instances to this client remaining.
+   * This differs from destroy() in that it will NOT block if there are any open instances of the fetched entity on any
+   * client.  In that case, it merely fails, returning false.
+   * 
+   * @return True if the entity was destroyed, false if there are fetched entities on any client.
+   * @throws EntityNotProvidedException The service providing T doesn't exist on either the client or the server
+   * @throws EntityNotFoundException No entity with this type and name could be found
+   */
+  boolean tryDestroy() throws EntityNotProvidedException, EntityNotFoundException;
+
+  /**
    * Gets the entity pointed to by this reference.  Never returns null but throws on error.
    * Note that the returned instance is in an "open" state and must be closed (using "close()") to release this hold on the
    * server-side instance.  Otherwise, attempts to destroy() it will block.  Multiple clients can hold a fetched reference

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessage.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessage.java
@@ -39,6 +39,7 @@ public abstract class PassthroughMessage {
     COMPLETE_FROM_SERVER,
     INVOKE_ON_CLIENT,
     LOCK_ACQUIRE,
+    LOCK_TRY_ACQUIRE,
     LOCK_RELEASE,
     LOCK_RESTORE,
     RECONNECT,

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
@@ -162,6 +162,17 @@ public class PassthroughMessageCodec {
       }};
   }
 
+  public static PassthroughMessage createWriteLockTryAcquireMessage(final Class<?> entityClass, final String entityName) {
+    // Lock-state is just an interaction between client and server which must be cleanly rebuilt on reconnect so don't replicate.
+    boolean shouldReplicateToPassives = false;
+    return new PassthroughMessage(Type.LOCK_TRY_ACQUIRE, shouldReplicateToPassives) {
+      @Override
+      protected void populateStream(DataOutputStream output) throws IOException {
+        output.writeUTF(entityClass.getCanonicalName());
+        output.writeUTF(entityName);
+      }};
+  }
+
   public static PassthroughMessage createWriteLockReleaseMessage(final Class<?> entityClass, final String entityName) {
     // Lock-state is just an interaction between client and server which must be cleanly rebuilt on reconnect so don't replicate.
     boolean shouldReplicateToPassives = false;

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -484,6 +484,12 @@ public class PassthroughServerProcess implements MessageHandler {
   }
 
   @Override
+  public boolean tryAcquireWriteLock(IMessageSenderWrapper sender, String entityClassName, String entityName) {
+    PassthroughEntityTuple entityTuple = new PassthroughEntityTuple(entityClassName, entityName);
+    return this.lockManager.tryAcquireWriteLock(entityTuple, sender.getClientOriginID());
+  }
+
+  @Override
   public void releaseWriteLock(IMessageSenderWrapper sender, String entityClassName, String entityName) {
     PassthroughEntityTuple entityTuple = new PassthroughEntityTuple(entityClassName, entityName);
     this.lockManager.releaseWriteLock(entityTuple, sender.getClientOriginID());


### PR DESCRIPTION
-this method is like destroy() but it will fail, instead of blocking, if it can't get the exclusive lock on the entity
-most of the change is updating passthrough to support this