### PR TITLE
Fix #41: Passthrough built-in service providers now implement PassthroughBuiltInServiceProvider

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughBuiltInServiceProvider.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughBuiltInServiceProvider.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import java.io.Closeable;
+import java.util.Collection;
+
+import org.terracotta.entity.ServiceConfiguration;
+
+
+public interface PassthroughBuiltInServiceProvider extends Closeable {
+  /**
+   * Get an instance of service from the provider.
+   *
+   * @param consumerID The unique ID used to name-space the returned service
+   * @param configuration Service configuration which is to be used
+   * @return service instance
+   */
+  <T> T getService(long consumerID, ServiceConfiguration<T> configuration);
+
+  /**
+   * Since a service provider can know how to build more than one type of service, this method allows the platform to query
+   * the extent of that capability.  Returned is a collection of service types which can be returned by getService.
+   *
+   * @return A collection of the types of services which can be returned by the receiver.
+   */
+  Collection<Class<?>> getProvidedServiceTypes();
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorServiceProvider.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorServiceProvider.java
@@ -19,31 +19,22 @@
 package org.terracotta.passthrough;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ServiceConfiguration;
-import org.terracotta.entity.ServiceProvider;
-import org.terracotta.entity.ServiceProviderConfiguration;
 
 
 /**
  * The provider of PassthroughCommunicatorService, to server-side entities.  It has no meaningful implementation beyond
  * providing that.
  */
-public class PassthroughCommunicatorServiceProvider implements ServiceProvider {
+public class PassthroughCommunicatorServiceProvider implements PassthroughBuiltInServiceProvider {
   @Override
   public void close() {
     // TODO Auto-generated method stub
     
-  }
-
-  @Override
-  public boolean initialize(ServiceProviderConfiguration configuration) {
-    // We always return true on initialize of this service (it has no state).
-    return true;
   }
 
   @Override

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -60,8 +60,7 @@ public class PassthroughServer {
     this.savedClientConnections = new HashMap<Long, PassthroughConnection>();
     
     // Register built-in services.
-    PassthroughCommunicatorServiceProvider communicatorServiceProvider = new PassthroughCommunicatorServiceProvider();
-    internalRegisterServiceProvider(communicatorServiceProvider, null);
+    registerBuiltInServices();
   }
 
   public void registerServerEntityService(ServerEntityService<?, ?> service) {
@@ -156,6 +155,9 @@ public class PassthroughServer {
     for (ServerEntityService<?, ?> serverEntityService : this.savedServerEntityServices) {
       this.serverProcess.registerEntityService(serverEntityService);
     }
+    // Install the built-in services.
+    registerBuiltInServices();
+    // Install the user-created services.
     for (ServiceProviderAndConfiguration tuple : this.savedServiceProviderData) {
       this.serverProcess.registerServiceProvider(tuple.serviceProvider, tuple.providerConfiguration);
     }
@@ -224,5 +226,10 @@ public class PassthroughServer {
       this.serviceProvider = serviceProvider;
       this.providerConfiguration = providerConfiguration;
     }
+  }
+
+  private void registerBuiltInServices() {
+    PassthroughCommunicatorServiceProvider communicatorServiceProvider = new PassthroughCommunicatorServiceProvider();
+    this.serverProcess.registerBuiltInServiceProvider(communicatorServiceProvider, null);
   }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -73,6 +73,7 @@ public class PassthroughServerProcess implements MessageHandler {
   private Map<PassthroughEntityTuple, CreationData<ActiveServerEntity<?, ?>>> activeEntities;
   private Map<PassthroughEntityTuple, CreationData<PassiveServerEntity<?, ?>>> passiveEntities;
   private final List<ServiceProvider> serviceProviders;
+  private final List<PassthroughBuiltInServiceProvider> builtInServiceProviders;
   private PassthroughServerProcess downstreamPassive;
   private long nextConsumerID;
   private PassthroughServiceRegistry platformServiceRegistry;
@@ -88,6 +89,7 @@ public class PassthroughServerProcess implements MessageHandler {
     this.activeEntities = (isActiveMode ? new HashMap<PassthroughEntityTuple, CreationData<ActiveServerEntity<?, ?>>>() : null);
     this.passiveEntities = (isActiveMode ? null : new HashMap<PassthroughEntityTuple, CreationData<PassiveServerEntity<?, ?>>>());
     this.serviceProviders = new Vector<ServiceProvider>();
+    this.builtInServiceProviders = new Vector<PassthroughBuiltInServiceProvider>();
     // Consumer IDs start at 0 since that is the one the platform gives itself.
     this.nextConsumerID = 0;
   }
@@ -106,7 +108,7 @@ public class PassthroughServerProcess implements MessageHandler {
       // Load the entities.
       for (long consumerID : this.persistedEntitiesByConsumerID.keySet()) {
         // Create the registry for the entity.
-        PassthroughServiceRegistry registry = new PassthroughServiceRegistry(consumerID, this.serviceProviders);
+        PassthroughServiceRegistry registry = new PassthroughServiceRegistry(consumerID, this.serviceProviders, this.builtInServiceProviders);
         // Construct the entity.
         EntityData entityData = this.persistedEntitiesByConsumerID.get(consumerID);
         ServerEntityService<?, ?> service = null;
@@ -681,6 +683,10 @@ public class PassthroughServerProcess implements MessageHandler {
     return foundService;
   }
 
+  public void registerBuiltInServiceProvider(PassthroughBuiltInServiceProvider serviceProvider, ServiceProviderConfiguration providerConfiguration) {
+    this.builtInServiceProviders.add(serviceProvider);
+  }
+
   public void registerServiceProvider(ServiceProvider serviceProvider, ServiceProviderConfiguration providerConfiguration) {
     // We run the initializer right away.
     boolean didInitialize = serviceProvider.initialize(providerConfiguration);
@@ -799,7 +805,7 @@ public class PassthroughServerProcess implements MessageHandler {
   private PassthroughServiceRegistry getNextServiceRegistry() {
     long thisConsumerID = this.nextConsumerID;
     this.nextConsumerID += 1;
-    return new PassthroughServiceRegistry(thisConsumerID, this.serviceProviders);
+    return new PassthroughServiceRegistry(thisConsumerID, this.serviceProviders, this.builtInServiceProviders);
   }
 
   private ServerEntityService<?, ?> getServerEntityServiceForVersion(String entityClassName, String entityName, long version) throws EntityVersionMismatchException {


### PR DESCRIPTION
-while this produces some nearly duplicated registration paths, it allows greater flexibility in terms of how built-in services can interact with the implementation