### PR TITLE
Fix #12: ClientCommunicator now takes EntityResponse as its argument

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughBuiltInServiceProvider.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughBuiltInServiceProvider.java
@@ -21,6 +21,7 @@ package org.terracotta.passthrough;
 import java.io.Closeable;
 import java.util.Collection;
 
+import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.entity.ServiceConfiguration;
 
 
@@ -29,10 +30,11 @@ public interface PassthroughBuiltInServiceProvider extends Closeable {
    * Get an instance of service from the provider.
    *
    * @param consumerID The unique ID used to name-space the returned service
+   * @param container The container which will eventually hold the entity instance (may be null if this is a non-entity consumer)
    * @param configuration Service configuration which is to be used
    * @return service instance
    */
-  <T> T getService(long consumerID, ServiceConfiguration<T> configuration);
+  <T> T getService(long consumerID, DeferredEntityContainer container, ServiceConfiguration<T> configuration);
 
   /**
    * Since a service provider can know how to build more than one type of service, this method allows the platform to query
@@ -41,4 +43,17 @@ public interface PassthroughBuiltInServiceProvider extends Closeable {
    * @return A collection of the types of services which can be returned by the receiver.
    */
   Collection<Class<?>> getProvidedServiceTypes();
+
+
+  /**
+   * We currently don't have any abstract entity container which is created before the entity is physically instantiated
+   * so we use this class in order to describe where an entity will eventually live when creating the service instance for
+   * this entity.
+   * The reason for this is that the entity constructor may ask to get a service which means that the entity isn't yet known
+   * to the platform.  So long as the entity doesn't try to use a built-in service in its constructor, but only requests it,
+   * then this allows us to defer the connection.
+   */
+  public static class DeferredEntityContainer {
+    public CommonServerEntity<?, ?> entity;
+  }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorService.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Future;
 
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.passthrough.PassthroughBuiltInServiceProvider.DeferredEntityContainer;
 
 
 /**
@@ -30,6 +31,16 @@ import org.terracotta.entity.ClientDescriptor;
  * TODO:  we currently need to determine how to handle the synchronous send.
  */
 public class PassthroughCommunicatorService implements ClientCommunicator {
+  @SuppressWarnings("unused")
+  // Currently unused but in place for a later change.
+  private final DeferredEntityContainer container;
+
+  public PassthroughCommunicatorService(DeferredEntityContainer container) {
+    // Nobody should be able to request the communicator if they are a non-entity consumer (null container).
+    Assert.assertTrue(null != container);
+    this.container = container;
+  }
+
   @Override
   public void sendNoResponse(ClientDescriptor clientDescriptor, byte[] payload) {
     prepareAndSendMessage(clientDescriptor, payload);

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorService.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorService.java
@@ -22,6 +22,10 @@ import java.util.concurrent.Future;
 
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.CommonServerEntity;
+import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.MessageCodecException;
 import org.terracotta.passthrough.PassthroughBuiltInServiceProvider.DeferredEntityContainer;
 
 
@@ -31,8 +35,6 @@ import org.terracotta.passthrough.PassthroughBuiltInServiceProvider.DeferredEnti
  * TODO:  we currently need to determine how to handle the synchronous send.
  */
 public class PassthroughCommunicatorService implements ClientCommunicator {
-  @SuppressWarnings("unused")
-  // Currently unused but in place for a later change.
   private final DeferredEntityContainer container;
 
   public PassthroughCommunicatorService(DeferredEntityContainer container) {
@@ -42,22 +44,33 @@ public class PassthroughCommunicatorService implements ClientCommunicator {
   }
 
   @Override
-  public void sendNoResponse(ClientDescriptor clientDescriptor, byte[] payload) {
-    prepareAndSendMessage(clientDescriptor, payload);
+  public void sendNoResponse(ClientDescriptor clientDescriptor, EntityResponse message) throws MessageCodecException {
+    prepareAndSendMessage(clientDescriptor, message);
   }
 
   @Override
-  public Future<Void> send(ClientDescriptor clientDescriptor, byte[] payload) {
-    return prepareAndSendMessage(clientDescriptor, payload);
+  public Future<Void> send(ClientDescriptor clientDescriptor, EntityResponse message) throws MessageCodecException {
+    return prepareAndSendMessage(clientDescriptor, message);
   }
 
-  private Future<Void> prepareAndSendMessage(ClientDescriptor clientDescriptor, byte[] payload) {
+  private Future<Void> prepareAndSendMessage(ClientDescriptor clientDescriptor, EntityResponse entityMessage) throws MessageCodecException {
     PassthroughClientDescriptor rawDescriptor = (PassthroughClientDescriptor) clientDescriptor;
     PassthroughConnection connection = rawDescriptor.sender;
     long clientInstanceID = rawDescriptor.clientInstanceID;
     Future<Void> waiter = connection.createClientResponseFuture();
+    
+    // We know that the entity better exist, by this point, to use the service.
+    CommonServerEntity<?, ?> entity = this.container.entity;
+    Assert.assertTrue(null != entity);
+    byte[] payload = serialize(entity.getMessageCodec(), entityMessage);
     PassthroughMessage message = PassthroughMessageCodec.createMessageToClient(clientInstanceID, payload);
     connection.sendMessageToClient(rawDescriptor.server, message.asSerializedBytes());
     return waiter;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <R extends EntityResponse> byte[] serialize(MessageCodec<?, R> codec, EntityResponse message) throws MessageCodecException {
+    // Cast should be safe as message and codec are from the same implementation.
+    return codec.serialize((R)message);
   }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorServiceProvider.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorServiceProvider.java
@@ -38,8 +38,8 @@ public class PassthroughCommunicatorServiceProvider implements PassthroughBuiltI
   }
 
   @Override
-  public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
-    return configuration.getServiceType().cast(new PassthroughCommunicatorService());
+  public <T> T getService(long consumerID, DeferredEntityContainer container, ServiceConfiguration<T> configuration) {
+    return configuration.getServiceType().cast(new PassthroughCommunicatorService(container));
   }
 
   @Override

--- a/standard-cluster-services/src/main/java/org/terracotta/entity/ClientCommunicator.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/entity/ClientCommunicator.java
@@ -36,9 +36,10 @@ public interface ClientCommunicator {
    * Send a message to the client-side of an entity.
    *
    * @param clientDescriptor The client side instance to send to
-   * @param payload bytes to send
+   * @param message The message to send
+   * @throws MessageCodecException If the message could not be serialized by the provided codec
    */
-  void sendNoResponse(ClientDescriptor clientDescriptor, byte[] payload);
+  void sendNoResponse(ClientDescriptor clientDescriptor, EntityResponse message) throws MessageCodecException;
 
   /**
    * Send a message getting an async completion back.
@@ -48,9 +49,10 @@ public interface ClientCommunicator {
    * THIS METHOD
    * 
    * @param clientDescriptor The client side instance to send to
-   * @param payload bytes to send
+   * @param message The message to send
    * @return Future representing when the client finishes with and acknowledges the sent message.
+   * @throws MessageCodecException If the message could not be serialized by the provided codec
    */
   @Deprecated
-  Future<Void> send(ClientDescriptor clientDescriptor, byte[] payload);
+  Future<Void> send(ClientDescriptor clientDescriptor, EntityResponse message) throws MessageCodecException;
 }


### PR DESCRIPTION
-this gives a higher-level meaning than was conveyed by byte[]
-this requires that the ClientCommunicator can access the codec used by the entity