### PR TITLE
Throws a EntityNotProvidedException instead of a NPE when no ServerEn…

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -43,6 +43,7 @@ import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityException;
 import org.terracotta.exception.EntityNotFoundException;
+import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityUserException;
 import org.terracotta.exception.EntityVersionMismatchException;
 import org.terracotta.monitoring.IMonitoringProducer;
@@ -816,8 +817,11 @@ public class PassthroughServerProcess implements MessageHandler {
     return new PassthroughServiceRegistry(thisConsumerID, this.serviceProviders, this.builtInServiceProviders, container);
   }
 
-  private ServerEntityService<?, ?> getServerEntityServiceForVersion(String entityClassName, String entityName, long version) throws EntityVersionMismatchException {
+  private ServerEntityService<?, ?> getServerEntityServiceForVersion(String entityClassName, String entityName, long version) throws EntityVersionMismatchException, EntityNotProvidedException {
     ServerEntityService<?, ?> service = getEntityServiceForClassName(entityClassName);
+    if(service == null) {
+      throw new EntityNotProvidedException(entityClassName, entityName);
+    }
     long expectedVersion = service.getVersion();
     if (expectedVersion != version) {
       throw new EntityVersionMismatchException(entityClassName, entityName, expectedVersion, version);


### PR DESCRIPTION
…tityService found for an entity class name

If a ServerEntityService is not found for a given entity class name (i.e. id the method `ServerEntityService.handlesEntityType` is badly implemented), we end up with the following exception:

```
Caused by: java.lang.NullPointerException
	at org.terracotta.passthrough.PassthroughServerProcess.getServerEntityServiceForVersion(PassthroughServerProcess.java:821)
	at org.terracotta.passthrough.PassthroughServerProcess.create(PassthroughServerProcess.java:490)
	at org.terracotta.passthrough.PassthroughServerMessageDecoder.decode(PassthroughServerMessageDecoder.java:74)
	... 8 more
```

So this path just throws a better exception (though you'll have to check if it is the right one):

```
org.terracotta.exception.EntityNotProvidedException: Entity: com.terracottatech.management.voltron.tms.entity.client.TmsAgentEntity:TmsAgentEntity no provider found for class

	at org.terracotta.passthrough.PassthroughServerProcess.getServerEntityServiceForVersion(PassthroughServerProcess.java:823)
	at org.terracotta.passthrough.PassthroughServerProcess.create(PassthroughServerProcess.java:491)
	at org.terracotta.passthrough.PassthroughServerMessageDecoder.decode(PassthroughServerMessageDecoder.java:74)
	at org.terracotta.passthrough.PassthroughServerMessageDecoder.decode(PassthroughServerMessageDecoder.java:35)
	at org.terracotta.passthrough.PassthroughMessageCodec.runRawDecoder(PassthroughMessageCodec.java:353)
	at org.terracotta.passthrough.PassthroughMessageCodec.decodeRawMessage(PassthroughMessageCodec.java:277)
	at org.terracotta.passthrough.PassthroughServerProcess.serverThreadHandleMessage(PassthroughServerProcess.java:317)
	at org.terracotta.passthrough.PassthroughServerProcess.runServerThread(PassthroughServerProcess.java:293)
	at org.terracotta.passthrough.PassthroughServerProcess.access$000(PassthroughServerProcess.java:66)
	at org.terracotta.passthrough.PassthroughServerProcess$2.run(PassthroughServerProcess.java:174)
	at java.lang.Thread.run(Thread.java:745)
```