### PR TITLE
Track transaction history of create/destroy/reconfigure for re-send short-circuit

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/IMessageSenderWrapper.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/IMessageSenderWrapper.java
@@ -36,12 +36,4 @@ public interface IMessageSenderWrapper {
    * @return The client origin unique ID.
    */
   long getClientOriginID();
-  /**
-   * Note that this is a temporary work-around to test re-sent create/destroy messages which the server can't ignore as
-   * duplicated.
-   * XXX: This should be replaced with precise transaction order persistence with special tracking for these internal
-   * messages which must be ignored as duplicated.
-   * @return True if create or destroy messages which may to be duplicated should be treated as successes.
-   */
-  boolean shouldTolerateCreateDestroyDuplication();
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
@@ -170,7 +170,7 @@ public class PassthroughConnection implements Connection {
   private void clientThreadHandleMessage(final PassthroughServerProcess sender, byte[] message) {
     PassthroughMessageCodec.Decoder<Void> decoder = new PassthroughMessageCodec.Decoder<Void>() {
       @Override
-      public Void decode(Type type, boolean shouldReplicate, long transactionID, DataInputStream input) throws IOException {
+      public Void decode(Type type, boolean shouldReplicate, long transactionID, long oldestTransactionID, DataInputStream input) throws IOException {
         switch (type) {
           case ACK_FROM_SERVER:
             handleAck(sender, transactionID);

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnectionState.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnectionState.java
@@ -76,8 +76,7 @@ public class PassthroughConnectionState {
     }
     byte[] raw = message.asSerializedBytes();
     waiter.saveRawMessageForResend(raw);
-    boolean isResend = false;
-    target.sendMessageToServer(sender, raw, isResend);
+    target.sendMessageToServer(sender, raw);
     return waiter;
   }
 
@@ -111,8 +110,7 @@ public class PassthroughConnectionState {
     Assert.assertTrue(null != this.reconnectingServerProcess);
     byte[] raw = waiter.resetAndGetMessageForResend();
     this.reconnectingInFlightMessages.put(transactionID, waiter);
-    boolean isResend = true;
-    this.reconnectingServerProcess.sendMessageToServer(sender, raw, isResend);
+    this.reconnectingServerProcess.sendMessageToServer(sender, raw);
   }
 
   public synchronized PassthroughWait getWaiterForTransaction(PassthroughServerProcess sender, long transactionID) {

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughInterserverInterlock.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughInterserverInterlock.java
@@ -57,9 +57,4 @@ public class PassthroughInterserverInterlock implements IMessageSenderWrapper {
   public long getClientOriginID() {
     return sender.getClientOriginID();
   }
-  @Override
-  public boolean shouldTolerateCreateDestroyDuplication() {
-    // We will use whatever the underlying sender thinks.
-    return sender.shouldTolerateCreateDestroyDuplication();
-  }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughLifeCycleHandler.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughLifeCycleHandler.java
@@ -1,0 +1,156 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import org.terracotta.exception.EntityException;
+import org.terracotta.passthrough.PassthroughServerMessageDecoder.LifeCycleMessageHandler;
+import org.terracotta.persistence.IPersistentStorage;
+import org.terracotta.persistence.KeyValueStorage;
+
+
+/**
+ * This implementation has 2 different modes (may be worth splitting this into a few classes if it ever becomes complex but much of the code is the same):
+ * 1) Backed by KeyValueStorage.
+ * 2) Backed by Map.
+ * The core logic which manipulates the data stored in either of these is the same, only how it is loaded or written-back.
+ */
+public class PassthroughLifeCycleHandler implements LifeCycleMessageHandler {
+  private final KeyValueStorage<Long, List<LifeCycleRecord>> lifeCycleRecordByClientID;
+  private final Map<Long, List<LifeCycleRecord>> fallbackMap;
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public PassthroughLifeCycleHandler(IPersistentStorage persistentStorage, String topLevelName) {
+    if (null != persistentStorage) {
+      this.lifeCycleRecordByClientID = persistentStorage.getKeyValueStorage(topLevelName, Long.class, (Class)List.class);
+      this.fallbackMap = null;
+    } else {
+      this.lifeCycleRecordByClientID = null;
+      this.fallbackMap = new HashMap<Long, List<LifeCycleRecord>>();
+    }
+  }
+
+  @Override
+  public boolean didAlreadyHandle(long clientOriginID, long transactionID) throws EntityException {
+    boolean didHandle = false;
+    List<LifeCycleRecord> records = loadClient(clientOriginID);
+    if (null != records) {
+      for (LifeCycleRecord record : records) {
+        if (record.transactionID == transactionID) {
+          if (null == record.error) {
+            // Success.
+            didHandle = true;
+            break;
+          } else {
+            // We know about this but it was a failure.
+            throw record.error;
+          }
+        }
+      }
+    }
+    return didHandle;
+  }
+
+  @Override
+  public byte[] didAlreadyHandleResult(long clientOriginID, long transactionID) throws EntityException {
+    byte[] result = null;
+    List<LifeCycleRecord> records = loadClient(clientOriginID);
+    if (null != records) {
+      for (LifeCycleRecord record : records) {
+        if (record.transactionID == transactionID) {
+          if (null == record.error) {
+            // Success.
+            Assert.assertTrue(null != record.reconfigureResult);
+            result = record.reconfigureResult;
+            break;
+          } else {
+            // We know about this but it was a failure.
+            throw record.error;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public void failureInMessage(long clientOriginID, long transactionID, long oldestTransactionID, EntityException error) {
+    addNewRecord(clientOriginID, transactionID, oldestTransactionID, null, error);
+  }
+
+  @Override
+  public void successInMessage(long clientOriginID, long transactionID, long oldestTransactionID, byte[] reconfigureResponse) {
+    // Null error on success.
+    EntityException error = null;
+    addNewRecord(clientOriginID, transactionID, oldestTransactionID, reconfigureResponse, error);
+  }
+
+
+  private void addNewRecord(long clientOriginID, long transactionID, long oldestTransactionID, byte[] reconfigureResult, EntityException error) {
+    List<LifeCycleRecord> newRecords = filteredRecords(clientOriginID, oldestTransactionID);
+    LifeCycleRecord newRecord = new LifeCycleRecord();
+    newRecord.transactionID = transactionID;
+    newRecord.reconfigureResult = reconfigureResult;
+    newRecord.error = error;
+    newRecords.add(newRecord);
+    storeClient(clientOriginID, newRecords);
+  }
+
+  private List<LifeCycleRecord> filteredRecords(long clientOriginID, long oldestTransactionID) {
+    List<LifeCycleRecord> records = loadClient(clientOriginID);
+    if (null == records) {
+      records = new Vector<LifeCycleRecord>();
+    }
+    List<LifeCycleRecord> newRecords = new Vector<LifeCycleRecord>();
+    for (LifeCycleRecord record : records) {
+      if (record.transactionID >= oldestTransactionID) {
+        newRecords.add(record);
+      }
+    }
+    return newRecords;
+  }
+
+  private List<LifeCycleRecord> loadClient(long clientOriginID) {
+    return (null != this.lifeCycleRecordByClientID)
+        ? this.lifeCycleRecordByClientID.get(clientOriginID)
+        : this.fallbackMap.get(clientOriginID);
+  }
+
+  private void storeClient(long clientOriginID, List<LifeCycleRecord> data) {
+    if (null != this.lifeCycleRecordByClientID) {
+      this.lifeCycleRecordByClientID.put(clientOriginID, data);
+    } else {
+      this.fallbackMap.put(clientOriginID, data);
+    }
+  }
+
+
+  private static class LifeCycleRecord implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
+    public long transactionID;
+    public byte[] reconfigureResult;
+    public EntityException error;
+  }
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessage.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessage.java
@@ -59,14 +59,16 @@ public abstract class PassthroughMessage {
   public final Type type;
   public final boolean shouldReplicateToPassives;
   public long transactionID;
+  public long oldestTransactionID;
   
   public PassthroughMessage(Type type, boolean shouldReplicateToPassives) {
     this.shouldReplicateToPassives = shouldReplicateToPassives;
     this.type = type;
   }
 
-  public void setTransactionID(long transactionID) {
+  public void setTransactionTracking(long transactionID, long oldestTransactionID) {
     this.transactionID = transactionID;
+    this.oldestTransactionID = oldestTransactionID;
   }
 
   public byte[] asSerializedBytes() {
@@ -76,6 +78,7 @@ public abstract class PassthroughMessage {
       output.writeInt(this.type.ordinal());
       output.writeBoolean(this.shouldReplicateToPassives);
       output.writeLong(this.transactionID);
+      output.writeLong(this.oldestTransactionID);
       this.populateStream(output);
       output.close();
     } catch (IOException e) { 

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageCodec.java
@@ -294,7 +294,7 @@ public class PassthroughMessageCodec {
     Decoder<Long> decoder = new Decoder<Long>() {
 
       @Override
-      public Long decode(Type type, boolean shouldReplicate, long transactionID, DataInputStream input) throws IOException {
+      public Long decode(Type type, boolean shouldReplicate, long transactionID, long oldestTransactionID, DataInputStream input) throws IOException {
         return transactionID;
       }
     };
@@ -305,7 +305,7 @@ public class PassthroughMessageCodec {
     Decoder<Type> decoder = new Decoder<Type>() {
 
       @Override
-      public Type decode(Type type, boolean shouldReplicate, long transactionID, DataInputStream input) throws IOException {
+      public Type decode(Type type, boolean shouldReplicate, long transactionID, long oldestTransactionID, DataInputStream input) throws IOException {
         // The type is an int ordinal after the transactionID.
         input.readLong();
         int ordinal = input.readInt();
@@ -363,7 +363,8 @@ public class PassthroughMessageCodec {
       Type type = Type.values()[ordinal];
       boolean shouldReplicate = input.readBoolean();
       long transactionID = input.readLong();
-      result = decoder.decode(type, shouldReplicate, transactionID, input);
+      long oldestTransactionID = input.readLong();
+      result = decoder.decode(type, shouldReplicate, transactionID, oldestTransactionID, input);
     } catch (IOException e) {
       // Can't happen with a byte array.
       Assert.unexpected(e);
@@ -372,6 +373,6 @@ public class PassthroughMessageCodec {
   }
 
   public interface Decoder<R> {
-    public R decode(Type type, boolean shouldReplicate, long transactionID, DataInputStream input) throws IOException;
+    public R decode(Type type, boolean shouldReplicate, long transactionID, long oldestTransactionID, DataInputStream input) throws IOException;
   }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerMessageDecoder.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerMessageDecoder.java
@@ -45,10 +45,12 @@ public class PassthroughServerMessageDecoder implements PassthroughMessageCodec.
     this.message = message;
   }
   @Override
-  public Void decode(Type type, boolean shouldReplicate, final long transactionID, DataInputStream input) throws IOException {
+  public Void decode(Type type, boolean shouldReplicate, final long transactionID, final long oldestTransactionID, DataInputStream input) throws IOException {
     // First step, send the ack.
     PassthroughMessage ack = PassthroughMessageCodec.createAckMessage();
-    ack.setTransactionID(transactionID);
+    // The oldestTransactionID isn't relevant when sent back.
+    long oldestTransactionIDToReturn = -1;
+    ack.setTransactionTracking(transactionID, oldestTransactionIDToReturn);
     sender.sendAck(ack);
     
     // Now, before we can actually RUN the message, we need to make sure that we wait for its replicated copy to complete
@@ -422,7 +424,9 @@ public class PassthroughServerMessageDecoder implements PassthroughMessageCodec.
 
   private void sendCompleteResponse(IMessageSenderWrapper sender, long transactionID, byte[] response, EntityException error) {
     PassthroughMessage complete = PassthroughMessageCodec.createCompleteMessage(response, error);
-    complete.setTransactionID(transactionID);
+    // The oldestTransactionID isn't relevant when sent back.
+    long oldestTransactionID = -1;
+    complete.setTransactionTracking(transactionID, oldestTransactionID);
     sender.sendComplete(complete);
   }
 

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -136,9 +136,6 @@ public class PassthroughServerProcess implements MessageHandler {
           this.nextConsumerID = consumerID + 1;
         }
       }
-      
-      // Get the persisted transaction order in case of a reconnect
-      this.persistedEntitiesByConsumerID = persistentStorage.getKeyValueStorage("entities", Long.class, EntityData.class);
     }
     
     // Look up the service interface the platform will use to publish events.


### PR DESCRIPTION
-this removes the problematic shouldTolerateCreateDestroyDuplication() work-around to avoid errors in re-sent life-cycle messages
-we now track create/destroy/reconfigure messages so that consistent answers can be give, on re-send