### PR TITLE
fixes to support reconfigure on clustered map

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityRef.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityRef.java
@@ -119,7 +119,6 @@ public class PassthroughEntityRef<T extends Entity, C> implements EntityRef<T, C
   public C reconfigure(C configuration) throws EntityException {
     // Make sure that we have a service provider.
     if (null != this.service) {
-      getWriteLock();
       try {
         byte[] serializedConfiguration = this.service.serializeConfiguration(configuration);
         PassthroughMessage reconfig = PassthroughMessageCodec.createReconfigureMessage(this.clazz.getCanonicalName(), this.name, this.version, serializedConfiguration);
@@ -141,7 +140,6 @@ public class PassthroughEntityRef<T extends Entity, C> implements EntityRef<T, C
           throw new RuntimeException(e);
         }
       } finally {
-        releaseWriteLock();
       }
     } else {
       throw new EntityNotProvidedException(this.clazz.getName(), this.name);

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -240,7 +240,10 @@ public class PassthroughServerProcess implements MessageHandler {
       this.notifyAll();
     }
     try {
-      this.serverThread.join();
+// multiple paths to shutdown.  This can happen multiple times without a new thread being created
+      if (this.serverThread != null) {
+        this.serverThread.join();
+      }
     } catch (InterruptedException e) {
       Assert.unexpected(e);
     }


### PR DESCRIPTION
Some fixes to support reconfigure in passthrough.  

* do not take an exclusive lock for reconfigure.  It doesn't need it, MANAGEMENT_KEY exclusive mode provides enough isolation

* Services need to be completely rebuilt on restarts

*  close hook may not need to run after failover