### PR TITLE
Proposal for getWithTimeout()

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughWait.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughWait.java
@@ -111,7 +111,7 @@ public class PassthroughWait implements InvokeFuture<byte[]> {
 
   @Override
   public byte[] getWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, EntityException, TimeoutException {
-    throw new IllegalStateException("Not supported");
+    return get();
   }
 
   public synchronized void sent() {


### PR DESCRIPTION
We are now using getWithTimeout(). Sadly our api tests are failing now because the method is not implemented.

@jd0-sag @myronkscott : Could it be possible to redirect it to get() for the moment ?