### PR TITLE
Add Client PID to PlatformConnectedClient

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -466,7 +466,7 @@ public class PassthroughServerProcess implements MessageHandler {
               // Record that this entity has been fetched by this client.
               String clientIdentifier = clientIdentifierForService(sender.getClientOriginID());
               String entityIdentifier = entityIdentifierForService(entityClassName, entityName);
-              PlatformClientFetchedEntity record = new PlatformClientFetchedEntity(clientIdentifier, entityIdentifier);
+              PlatformClientFetchedEntity record = new PlatformClientFetchedEntity(clientIdentifier, entityIdentifier, clientDescriptor);
               String fetchIdentifier = fetchIdentifierForService(clientIdentifier, entityIdentifier);
               PassthroughServerProcess.this.serviceInterface.addNode(PlatformMonitoringConstants.FETCHED_PATH, fetchIdentifier, record);
             }
@@ -836,7 +836,7 @@ public class PassthroughServerProcess implements MessageHandler {
         // We don't have handling for this.
         Assert.unexpected(e);
       }
-      PlatformConnectedClient clientDescription = new PlatformConnectedClient(localHost, this.bindPort, localHost, CLIENT_PORT.getAndIncrement());
+      PlatformConnectedClient clientDescription = new PlatformConnectedClient(localHost, this.bindPort, localHost, CLIENT_PORT.getAndIncrement(), -1);
       String nodeName = clientIdentifierForService(connectionID);
       this.serviceInterface.addNode(PlatformMonitoringConstants.CLIENTS_PATH, nodeName, clientDescription);
     }

--- a/monitoring-support/pom.xml
+++ b/monitoring-support/pom.xml
@@ -37,5 +37,10 @@
       <artifactId>packaging-support</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>entity-server-api</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformClientFetchedEntity.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformClientFetchedEntity.java
@@ -19,6 +19,7 @@
 package org.terracotta.monitoring;
 
 import com.tc.classloader.CommonComponent;
+import org.terracotta.entity.ClientDescriptor;
 
 
 /**
@@ -28,9 +29,11 @@ import com.tc.classloader.CommonComponent;
 public class PlatformClientFetchedEntity {
   public final String clientIdentifier;
   public final String entityIdentifier;
+  public final ClientDescriptor clientDescriptor;
 
-  public PlatformClientFetchedEntity(String clientIdentifier, String entityIdentifier) {
+  public PlatformClientFetchedEntity(String clientIdentifier, String entityIdentifier, ClientDescriptor clientDescriptor) {
     this.clientIdentifier = clientIdentifier;
     this.entityIdentifier = entityIdentifier;
+    this.clientDescriptor = clientDescriptor;
   }
 }

--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformConnectedClient.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformConnectedClient.java
@@ -32,11 +32,13 @@ public class PlatformConnectedClient {
   public final int localPort;
   public final InetAddress remoteAddress;
   public final int remotePort;
+  public final long clientPID;
 
-  public PlatformConnectedClient(InetAddress localAddress, int localPort, InetAddress remoteAddress, int remotePort) {
+  public PlatformConnectedClient(InetAddress localAddress, int localPort, InetAddress remoteAddress, int remotePort, long clientPID) {
     this.localAddress = localAddress;
     this.localPort = localPort;
     this.remoteAddress = remoteAddress;
     this.remotePort = remotePort;
+    this.clientPID = clientPID;
   }
 }


### PR DESCRIPTION
This PR adds Client PID to PlatformConnectedClient and ClientDescriptor to PlatformClientFetchedEntity. 

With these changes server entities can look up PlatformConnectedClient like this 

1. Server entity looks up **PlatformClientFetchedEntity** using **ClientDescriptor** by iterating through list of **PlatformClientFetchedEntity** available in platform monitoring tree
2. Look up **PlatformConnectedClient** using **clientIdentifier** from **PlatformClientFetchedEntity** found in step 1