### PR TITLE
Fix #45: EndpointDelegate.handleMessage() now takes EntityResponse instead of byte[]

### DIFF
--- a/entity-client-api/src/main/java/org/terracotta/entity/EndpointDelegate.java
+++ b/entity-client-api/src/main/java/org/terracotta/entity/EndpointDelegate.java
@@ -26,11 +26,14 @@ package org.terracotta.entity;
  */
 public interface EndpointDelegate {
   /**
-   * Handle a message coming from the clustered implementation of the Entity
+   * Handle a message coming from the clustered implementation of the Entity.
+   * Note that the message comes back as an EntityResponse object, maintaining consistency with the normal message flow:
+   * -client->server (EntityMessage)
+   * -server->client (EntityResponse)
    *
-   * @param payload serialized message
+   * @param messageFromServer The EntityResponse object sent by the server
    */
-  public void handleMessage(byte[] payload);
+  public void handleMessage(EntityResponse messageFromServer);
 
   /**
    * Called on the thread handling the reconnect to ask if any additional data should be provided to the server-side entity,

--- a/entity-test-lib/src/main/java/org/terracotta/entity/PassthroughEndpoint.java
+++ b/entity-test-lib/src/main/java/org/terracotta/entity/PassthroughEndpoint.java
@@ -151,9 +151,11 @@ public class PassthroughEndpoint<M extends EntityMessage, R extends EntityRespon
       if (clientDescriptor == PassthroughEndpoint.this.clientDescriptor) {
         if (null != PassthroughEndpoint.this.delegate) {
           try {
+            // We will encode and decode the message, to simulate how this would function over a network.
             @SuppressWarnings("unchecked")
             byte[] payload = PassthroughEndpoint.this.codec.encodeResponse((R)message);
-            PassthroughEndpoint.this.delegate.handleMessage(payload);
+            R fromServer = PassthroughEndpoint.this.codec.decodeResponse(payload);
+            PassthroughEndpoint.this.delegate.handleMessage(fromServer);
           } catch (MessageCodecException e) {
             // Unexpected in this test.
             Assert.fail();

--- a/entity-test-lib/src/main/java/org/terracotta/entity/PassthroughStripe.java
+++ b/entity-test-lib/src/main/java/org/terracotta/entity/PassthroughStripe.java
@@ -94,14 +94,24 @@ public class PassthroughStripe<M extends EntityMessage, R extends EntityResponse
   public void sendNoResponse(ClientDescriptor clientDescriptor, EntityResponse message) {
     FakeEndpoint endpoint = endpoints.get(clientDescriptor);
     byte[] payload = endpoint.serializeResponse(message);
-    endpoint.sendNoResponse(payload);
+    try {
+      endpoint.sendNoResponse(payload);
+    } catch (MessageCodecException e) {
+      // Not expected in the testing environment.
+      Assert.fail(e.getLocalizedMessage());
+    }
   }
 
   @Override
   public Future<Void> send(ClientDescriptor clientDescriptor, EntityResponse message) {
     FakeEndpoint endpoint = endpoints.get(clientDescriptor);
     byte[] payload = endpoint.serializeResponse(message);
-    endpoints.get(clientDescriptor).sendNoResponse(payload);
+    try {
+      endpoints.get(clientDescriptor).sendNoResponse(payload);
+    } catch (MessageCodecException e) {
+      // Not expected in the testing environment.
+      Assert.fail(e.getLocalizedMessage());
+    }
     return Futures.immediateFuture(null);
   }
 
@@ -137,9 +147,10 @@ public class PassthroughStripe<M extends EntityMessage, R extends EntityResponse
       return raw;
     }
 
-    public void sendNoResponse(byte[] payload) {
+    public void sendNoResponse(byte[] payload) throws MessageCodecException {
       if (null != this.delegate) {
-        this.delegate.handleMessage(payload);
+        R fromServer = this.codec.decodeResponse(payload);
+        this.delegate.handleMessage(fromServer);
       }
     }
 

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityClientEndpoint.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughEntityClientEndpoint.java
@@ -22,6 +22,7 @@ import org.terracotta.entity.EndpointDelegate;
 import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.InvocationBuilder;
 import org.terracotta.entity.InvokeFuture;
+import org.terracotta.entity.MessageCodecException;
 import org.terracotta.exception.EntityException;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
@@ -103,9 +104,10 @@ public class PassthroughEntityClientEndpoint<M extends EntityMessage, R extends 
     }
   }
 
-  public void handleMessageFromServer(byte[] payload) {
+  public void handleMessageFromServer(byte[] payload) throws MessageCodecException {
     if (null != this.delegate) {
-      this.delegate.handleMessage(payload);
+      R fromServer = this.messageCodec.decodeResponse(payload);
+      this.delegate.handleMessage(fromServer);
     }
   }
 


### PR DESCRIPTION
-this now matches the type sent through ClientCommunicator (which is other end of the pipe - sending messages received here)
-the passthrough implementation is also updated to work this way, even adding some gratuitous encode/decode operations in order to better simulate the network