### PR TITLE
Fix #80: Created "passthrough" URI and ConnectionService

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnectionService.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnectionService.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import java.net.URI;
+import java.rmi.UnknownHostException;
+import java.util.Properties;
+
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionService;
+
+
+/**
+ * Accesses PassthroughServer instances by URI.
+ * The named server must first be registered in the shared PassthroughServerRegistry shared instance for the host name given
+ * in the URI.  A URI of the shape "passthrough://serverName" will attempt to resolve the server registered as "serverName".
+ * 
+ * The special concern to realize, regarding our use of passthrough, is that we will treat an entire stripe (an active and
+ * any number of corresponding passives) as the same "named" PassthroughServer.  Even if this changes, it should always be
+ * sufficient to describe a stripe as a "name", instead of worrying about individual servers within a stripe (since there is
+ * no network).
+ * 
+ * Note that this ConnectionService is only accessible if "org.terracotta.passthrough.PassthroughConnectionService"
+ * is listed in "META-INF/services/org.terracotta.connection.ConnectionService".
+ */
+public class PassthroughConnectionService implements ConnectionService {
+  private static final String SCHEME = "passthrough";
+
+  @Override
+  public boolean handlesURI(URI uri) {
+    return SCHEME.equals(uri.getScheme());
+  }
+
+  @Override
+  public Connection connect(URI uri, Properties properties) throws ConnectionException {
+    Connection connection = null;
+    String serverName = uri.getHost();
+    PassthroughServer server = PassthroughServerRegistry.getSharedInstance().getServerForName(serverName);
+    if (null != server) {
+      connection = server.connectNewClient();
+    } else {
+      throw new ConnectionException(new UnknownHostException(serverName));
+    }
+    return connection;
+  }
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerRegistry.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerRegistry.java
@@ -1,0 +1,82 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Exists to support PassthroughConnectionService.  No context can be passed into that service so this represents the shared
+ * static interaction point, between PassthroughConnectionService and the testing code.
+ * The idea is that each server is registered with a name and that makes the server addressable by URI:
+ * -"serverName" is addressed as "passthrough://serverName"
+ */
+public class PassthroughServerRegistry {
+  private static PassthroughServerRegistry sharedInstance;
+
+  /**
+   * Lazily creates the shared instance, if it doesn't already exist.
+   * 
+   * @return The shared registry instance
+   */
+  public static PassthroughServerRegistry getSharedInstance() {
+    if (null == PassthroughServerRegistry.sharedInstance) {
+      PassthroughServerRegistry.sharedInstance = new PassthroughServerRegistry();
+    }
+    return PassthroughServerRegistry.sharedInstance;
+  }
+
+  private final Map<String, PassthroughServer> servers;
+
+  private PassthroughServerRegistry() {
+    this.servers = new HashMap<String, PassthroughServer>();
+  }
+
+  /**
+   * Registers a passthrough server with the given serverName.
+   * 
+   * @param serverName The name to use in addressing this server
+   * @param server The server to register
+   * @return The server previously registered with this name
+   */
+  public PassthroughServer registerServer(String serverName, PassthroughServer server) {
+    return this.servers.put(serverName, server);
+  }
+
+  /**
+   * Explicitly unregisters the server which had been registered with the given serverName.
+   * 
+   * @param serverName The name to unregister
+   * @return The instance which had been registered by this name
+   */
+  public PassthroughServer unregisterServer(String serverName) {
+    return this.servers.remove(serverName);
+  }
+
+  /**
+   * Gets the server registered as serverName.
+   * 
+   * @param serverName The name of the server to look-up
+   * @return The server instance
+   */
+  public PassthroughServer getServerForName(String serverName) {
+    return this.servers.get(serverName);
+  }
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTestHelpers.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTestHelpers.java
@@ -18,6 +18,8 @@
  */
 package org.terracotta.passthrough;
 
+import java.util.UUID;
+
 
 /**
  * Used for setting up IClusterControl instances to wrap test cluster configurations, based on the passthrough classes.
@@ -34,10 +36,12 @@ public class PassthroughTestHelpers {
    * @return A control object to use for interacting with the cluster.
    */
   public static IClusterControl createActiveOnly(ServerInitializer initializer) {
+    // We will synthesize a unique name for this stripe.
+    String stripeName = UUID.randomUUID().toString();
     boolean activeMode = true;
     PassthroughServer activeServer = intializeOneServer(initializer, activeMode);
     PassthroughServer passiveServer = null;
-    return new PassthroughClusterControl(activeServer, passiveServer);
+    return new PassthroughClusterControl(stripeName, activeServer, passiveServer);
   }
 
   /**
@@ -47,11 +51,13 @@ public class PassthroughTestHelpers {
    * @return A control object to use for interacting with the cluster.
    */
   public static IClusterControl createActivePassive(ServerInitializer initializer) {
+    // We will synthesize a unique name for this stripe.
+    String stripeName = UUID.randomUUID().toString();
     boolean activeMode = true;
     PassthroughServer activeServer = intializeOneServer(initializer, activeMode);
     PassthroughServer passiveServer = intializeOneServer(initializer, !activeMode);
     activeServer.attachDownstreamPassive(passiveServer);
-    return new PassthroughClusterControl(activeServer, passiveServer);
+    return new PassthroughClusterControl(stripeName, activeServer, passiveServer);
   }
 
   private static PassthroughServer intializeOneServer(ServerInitializer initializer, boolean activeMode) {


### PR DESCRIPTION
-for a PassthroughServer to be reachable via the PassthroughConnectionService, it needs to be registered in the global PassthroughServerRegistry
-the PassthroughServerRegistry is a global because there is no way to pass additional data into the ConnectionFactory to help resolve the server instance (it allows a way to hook into a synthetic name registry - emulating the network)