### PR TITLE
Fix #102: Throw IllegalStateException on closed connection/server

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -313,7 +313,11 @@ public class PassthroughServerProcess implements MessageHandler, PassthroughDump
   }
 
   public synchronized void sendMessageToServer(final PassthroughConnection sender, byte[] message) {
-    Assert.assertTrue(this.isRunning);
+    // If the server shut down, throw IllegalStateException
+    if (!this.isRunning) {
+      throw new IllegalStateException("Connection already closed");
+    }
+
     MessageContainer container = new MessageContainer();
     container.sender = new IMessageSenderWrapper() {
       @Override


### PR DESCRIPTION
-a more complete decision on what exceptions to throw, in these cases, still needs to be made
-this avoids the assertion failure which had been triggered, as a result of a previous change

(if nobody is able to test/merge this, tonight, I will get a local build of EhCache running to verify that this resolves the reported issue, in the morning)