### PR TITLE
Reconnect is now two-phase and re-sent messages are re-ordered

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/Assert.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/Assert.java
@@ -24,7 +24,7 @@ package org.terracotta.passthrough;
  */
 public class Assert {
 
-  public static void unexpected(Exception e) {
+  public static void unexpected(Throwable e) {
     throw (AssertionError) new AssertionError("Unexpected exception").initCause(e);
   }
 

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
@@ -506,16 +506,8 @@ public class PassthroughConnection implements Connection {
       long transactionID = entry.getKey();
       PassthroughWait waiter = entry.getValue();
       this.connectionState.sendAsResend(this, transactionID, waiter);
-      // This is a little heavy-handed but it gives us a clean state for leaving reconnect.
-      // We don't really care what the get does, just that it blocks until complete.
-      try {
-        waiter.get();
-      } catch (InterruptedException e) {
-        // Unexpected.
-        Throwables.propagate(e);
-      } catch (EntityException e) {
-        // We ignore this since someone will call the get(), later, in a more appropriate place.
-      }
+      // NOTE:  We cannot block on the get since the server won't send any acks until ALL re-sent messages are
+      // received.
     }
     
     // Now that we send the reconnect handshake and the re-sent transactions, we can install the new serverProcess and permit the new messages to go through.

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
@@ -498,7 +498,7 @@ public class PassthroughConnection implements Connection {
   /**
    * The second phase of the reconnect - re-send in-flight messages and exit the reconnecting state.
    */
-  public void finishReconnect(PassthroughServerProcess serverProcess) {
+  public void finishReconnect() {
     Assert.assertTrue(null != this.waitersToResend);
     
     // Re-send the existing in-flight messages - note that we need to take a snapshot of these instead of walking the map since it will change as the responses come back.

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughInterserverInterlock.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughInterserverInterlock.java
@@ -71,6 +71,12 @@ public class PassthroughInterserverInterlock implements IMessageSenderWrapper {
   }
   @Override
   public long getClientOriginID() {
-    return sender.getClientOriginID();
+    // Note that we will have a null sender when this is being used for sync messages.  Those are
+    // internally-originating messages so return -1.
+    long origin = -1;
+    if (null != sender) {
+      origin = sender.getClientOriginID();
+    }
+    return origin;
   }
 }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageContainer.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughMessageContainer.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+
+/**
+ * A class which ties together information related to a message.
+ * It is common since this container is useful in some public APIs.
+ */
+public class PassthroughMessageContainer {
+  public IMessageSenderWrapper sender;
+  public byte[] message;
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -236,7 +236,10 @@ public class PassthroughServer implements PassthroughDumper {
       
       // Reconnect all the connections.
       for(PassthroughConnection connection : this.savedClientConnections.values()) {
-        connection.reconnect(this.serverProcess);
+        connection.startReconnect(this.serverProcess);
+      }
+      for(PassthroughConnection connection : this.savedClientConnections.values()) {
+        connection.finishReconnect(this.serverProcess);
       }
       newActive = this;
     } else {
@@ -252,6 +255,9 @@ public class PassthroughServer implements PassthroughDumper {
       for(Map.Entry<Long, PassthroughConnection> connection : this.savedClientConnections.entrySet()) {
         newActive.failOverReconnect(connection.getKey(), connection.getValue());
       }
+      for(Map.Entry<Long, PassthroughConnection> connection : this.savedClientConnections.entrySet()) {
+        connection.getValue().finishReconnect(this.serverProcess);
+      }
       // Our clients are no longer connected to us so wipe them.
       this.savedClientConnections.clear();
     }
@@ -262,7 +268,7 @@ public class PassthroughServer implements PassthroughDumper {
     // Save this to our connection list.
     this.savedClientConnections.put(connectionID, connection);
     // Tell the connection to reconnect.
-    connection.reconnect(this.serverProcess);
+    connection.startReconnect(this.serverProcess);
   }
 
   private void doFailOver(PassthroughServer restartedAsPassive) {

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -238,9 +238,11 @@ public class PassthroughServer implements PassthroughDumper {
       for(PassthroughConnection connection : this.savedClientConnections.values()) {
         connection.startReconnect(this.serverProcess);
       }
+      this.serverProcess.beginReceivingResends();
       for(PassthroughConnection connection : this.savedClientConnections.values()) {
         connection.finishReconnect();
       }
+      this.serverProcess.endReceivingResends();
       newActive = this;
     } else {
       // Start us WITHOUT loading storage - this is because WE are the PASSIVE, now.
@@ -255,9 +257,11 @@ public class PassthroughServer implements PassthroughDumper {
       for(Map.Entry<Long, PassthroughConnection> connection : this.savedClientConnections.entrySet()) {
         newActive.failOverReconnect(connection.getKey(), connection.getValue());
       }
+      newActive.serverProcess.beginReceivingResends();
       for(Map.Entry<Long, PassthroughConnection> connection : this.savedClientConnections.entrySet()) {
         connection.getValue().finishReconnect();
       }
+      newActive.serverProcess.endReceivingResends();
       // Our clients are no longer connected to us so wipe them.
       this.savedClientConnections.clear();
     }

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -239,7 +239,7 @@ public class PassthroughServer implements PassthroughDumper {
         connection.startReconnect(this.serverProcess);
       }
       for(PassthroughConnection connection : this.savedClientConnections.values()) {
-        connection.finishReconnect(this.serverProcess);
+        connection.finishReconnect();
       }
       newActive = this;
     } else {
@@ -256,7 +256,7 @@ public class PassthroughServer implements PassthroughDumper {
         newActive.failOverReconnect(connection.getKey(), connection.getValue());
       }
       for(Map.Entry<Long, PassthroughConnection> connection : this.savedClientConnections.entrySet()) {
-        connection.getValue().finishReconnect(this.serverProcess);
+        connection.getValue().finishReconnect();
       }
       // Our clients are no longer connected to us so wipe them.
       this.savedClientConnections.clear();

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTransactionOrderManager.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTransactionOrderManager.java
@@ -1,0 +1,126 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import org.terracotta.persistence.IPersistentStorage;
+import org.terracotta.persistence.KeyValueStorage;
+
+
+public class PassthroughTransactionOrderManager {
+  // We will index this at 0 to get the actual list - only map types provided.
+  private KeyValueStorage<Long, List<ClientTransaction>> transactionOrderContainer;
+  
+  // This map is only available while handling re-sends.
+  private Map<ClientTransaction, PassthroughMessageContainer> collectedResends;
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public PassthroughTransactionOrderManager(IPersistentStorage persistentStorage) {
+    this.transactionOrderContainer = persistentStorage.getKeyValueStorage("transaction order", Long.class, (Class)List.class);
+  }
+
+  public void updateTracking(long connectionID, long transactionID, long oldestIDOnConnection) {
+    List<ClientTransaction> oldList = this.transactionOrderContainer.get(0L);
+    List<ClientTransaction> newList = new Vector<ClientTransaction>();
+    
+    if (null != oldList) {
+      for (ClientTransaction transaction : oldList) {
+        if (transaction.connectionID == connectionID) {
+          if (transaction.transactionID >= oldestIDOnConnection) {
+            newList.add(transaction);
+          } else {
+            // This is old, so drop it.
+          }
+        } else {
+          newList.add(transaction);
+        }
+      }
+    }
+    ClientTransaction newTransaction = new ClientTransaction();
+    newTransaction.connectionID = connectionID;
+    newTransaction.transactionID = transactionID;
+    newList.add(newTransaction);
+    this.transactionOrderContainer.put(0L, newList);
+  }
+
+  public void startHandlingResends() {
+    Assert.assertTrue(null == this.collectedResends);
+    this.collectedResends = new HashMap<ClientTransaction, PassthroughMessageContainer>();
+  }
+
+  public void handleResend(long connectionID, long transactionID, PassthroughMessageContainer container) {
+    Assert.assertTrue(null != this.collectedResends);
+    ClientTransaction fakeTransaction = new ClientTransaction();
+    fakeTransaction.connectionID = connectionID;
+    fakeTransaction.transactionID = transactionID;
+    this.collectedResends.put(fakeTransaction, container);
+  }
+
+  public List<PassthroughMessageContainer> stopHandlingResends() {
+    Assert.assertTrue(null != this.collectedResends);
+    List<PassthroughMessageContainer> orderToExecute = new Vector<PassthroughMessageContainer>();
+    
+    // First, walk the transaction order list, extracting any matches from the collectedResends.
+    List<ClientTransaction> orderList = this.transactionOrderContainer.get(0L);
+    if (null != orderList) {
+      for (ClientTransaction transaction : orderList) {
+        PassthroughMessageContainer container = this.collectedResends.remove(transaction);
+        if (null != container) {
+          orderToExecute.add(container);
+        }
+      }
+    }
+    
+    // Then, walk the remaining resends, adding them to the list in an arbitrary order.
+    for (PassthroughMessageContainer container : this.collectedResends.values()) {
+      orderToExecute.add(container);
+    }
+    
+    this.collectedResends = null;
+    return orderToExecute;
+  }
+
+
+  private static class ClientTransaction implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
+    public long connectionID;
+    public long transactionID;
+    
+    @Override
+    public boolean equals(Object obj) {
+      boolean doesMatch = (this == obj);
+      if (!doesMatch && (null != obj) && (getClass() == obj.getClass())) {
+        ClientTransaction other = (ClientTransaction) obj;
+        doesMatch = (connectionID == other.connectionID)
+            && (transactionID == other.transactionID);
+      }
+      return doesMatch;
+    }
+    @Override
+    public int hashCode() {
+      return ((int)connectionID << 16) | (int)transactionID;
+    }
+  }
+}

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughWait.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughWait.java
@@ -175,7 +175,7 @@ public class PassthroughWait implements InvokeFuture<byte[]> {
   /**
    * Resets the ACK wait state for the receiver and returns the raw message for the caller to re-send.
    */
-  public byte[] resetAndGetMessageForResend() {
+  public synchronized byte[] resetAndGetMessageForResend() {
     this.waitingForReceive = this.shouldWaitForReceived;
     this.waitingForComplete = this.shouldWaitForCompleted;
     this.waitingForRetired = this.shouldWaitForRetired;


### PR DESCRIPTION
Note that this required that transaction order is persisted, which can cause substantial slow-downs if a slow IPersistentStorage implementation is installed.