### PR TITLE
Add multi passive support in passthrough framework

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/IClusterControl.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/IClusterControl.java
@@ -42,6 +42,20 @@ public interface IClusterControl {
   public void waitForActive() throws Exception;
 
   /**
+   * Terminates current active of this Stripe
+   *
+   * @throws Exception A failure in terminating the server, defined by the implementation
+   */
+  public void terminateActive() throws Exception;
+
+  /**
+   * Starts the last terminated server
+   *
+   * @throws Exception A failure in starting, defined by the implementation
+   */
+  public void startLastTerminatedServer() throws Exception;
+
+  /**
    * Waits for the active server in the cluster to come online and determine that it is passive.
    * 
    * @throws Exception A failure waiting, defined by the implementation.

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughClusterControl.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughClusterControl.java
@@ -25,43 +25,165 @@ import org.terracotta.connection.ConnectionException;
 import org.terracotta.connection.ConnectionFactory;
 
 
+import java.util.ArrayList;
+import java.util.EmptyStackException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
+
+
 /**
- * The implementation used to control the passthrough testing cluster.
+ * TODO: Better rename this class as PassthroughStripeControl?
+ * The implementation used to control a passthrough testing cluster which can contain multiple servers
  */
 public class PassthroughClusterControl implements IClusterControl {
   private final String stripeName;
-  // We track the "original" server state for tear-down.
-  private final PassthroughServer originalActiveServer;
-  private final PassthroughServer originalPassiveServer;
-
-  // The active we are currently using can change on restart.
+  private List<PassthroughServer> passthroughServers = new ArrayList<PassthroughServer>();
+  private Set<PassthroughServer> stoppedPassthroughServers = new HashSet<PassthroughServer>();
+  private Stack<PassthroughServer> terminatedServersInOrder = new Stack<PassthroughServer>();
+  // elected active server
   private PassthroughServer activeServer;
 
-  public PassthroughClusterControl(String stripeName, PassthroughServer activeServer, PassthroughServer passiveServer) {
+  /**
+   * Constructs a PassthroughClusterControl with given stripeName and servers (at least one server needed to define a
+   * stripe)
+   *
+   * @param stripeName Stripe Name
+   * @param passthroughServer A {@link PassthroughServer}
+   * @param passthroughServers more {@link PassthroughServer}s
+   */
+  public PassthroughClusterControl(String stripeName, PassthroughServer passthroughServer, PassthroughServer... passthroughServers) {
     this.stripeName = stripeName;
-    // The active cannot be null but the passive can be.
-    Assert.assertTrue(null != activeServer);
-    this.originalActiveServer = activeServer;
-    this.originalPassiveServer = passiveServer;
-    // We set the changing active server to be the original.
-    this.activeServer = activeServer;
-    PassthroughServer previous = PassthroughServerRegistry.getSharedInstance().registerServer(this.stripeName, activeServer);
-    Assert.assertTrue(null == previous);
+    Assert.assertTrue(passthroughServer != null);
+    this.passthroughServers.add(passthroughServer);
+    for (PassthroughServer ps : passthroughServers) {
+      Assert.assertTrue(ps != null);
+      this.passthroughServers.add(ps);
+    }
+    bootstrapCluster();
   }
 
   @Override
-  public void restartActive() throws Exception {
-    this.activeServer = this.activeServer.restart();
+  public synchronized void restartActive() throws Exception {
+    Assert.assertTrue(this.activeServer != null);
+    final PassthroughServer prevActiveServer = this.activeServer;
+    this.activeServer = null;
+
+    // disconnect clients and stop current active
+    prevActiveServer.disconnectClients();
+    prevActiveServer.stop();
+
+    Assert.assertTrue(PassthroughServerRegistry.getSharedInstance().unregisterServer(this.stripeName) == prevActiveServer);
+
+    // add current active to stopped servers list, so that election code won't consider this server
+    this.stoppedPassthroughServers.add(prevActiveServer);
+
+    // elect active
+    PassthroughServer electedActive = electActive();
+
+    // if newly elected active is null, just use previous active server as current active server
+    // otherwise promote the elected active (was a passive) and start old active in passive mode
+    if(electedActive == null) {
+      electedActive = prevActiveServer;
+      boolean isActive = true;
+      boolean shouldStorageLoaded = true;
+      prevActiveServer.start(isActive, shouldStorageLoaded);
+    } else {
+      electedActive.promoteToActive();
+      boolean isActive = false;
+      boolean shouldStorageLoaded = false;
+      prevActiveServer.start(isActive, shouldStorageLoaded);
+    }
+
+    // previous active is alive now, remove it from stopped servers
+    this.stoppedPassthroughServers.remove(prevActiveServer);
+
+    // attach all passives to new active and connect clients from old active
+    attachPassivesToActive(electedActive);
+    prevActiveServer.connectSavedClientsTo(electedActive);
+
+    PassthroughServer prevActive = PassthroughServerRegistry.getSharedInstance().registerServer(this.stripeName, electedActive);
+    Assert.assertTrue(prevActive == null);
+
+    this.activeServer = electedActive;
+    this.notifyAll();
   }
 
   @Override
-  public void waitForActive() throws Exception {
-    // Do nothing - the restart brings up the active, immediately.
+  public synchronized void terminateActive() {
+    Assert.assertTrue(this.activeServer != null);
+    final PassthroughServer prevActiveServer = this.activeServer;
+    this.activeServer = null;
+
+    // disconnect clients and stop current active
+    prevActiveServer.disconnectClients();
+    prevActiveServer.stop();
+
+    Assert.assertTrue(PassthroughServerRegistry.getSharedInstance().unregisterServer(this.stripeName) == prevActiveServer);
+
+    // add current active to stopped servers list, so that election code won't consider this server
+    this.stoppedPassthroughServers.add(prevActiveServer);
+    this.terminatedServersInOrder.add(prevActiveServer);
+
+    final PassthroughServer electedActive = electActive();
+    //electedActive could be null, when there is only one server in this cluster
+    if(electedActive != null) {
+      electedActive.promoteToActive();
+
+      // attach all passives to new active and connect clients from old active
+      attachPassivesToActive(electedActive);
+      prevActiveServer.connectSavedClientsTo(electedActive);
+
+      PassthroughServer prevActive = PassthroughServerRegistry.getSharedInstance().registerServer(this.stripeName, electedActive);
+      Assert.assertTrue(prevActive == null);
+
+      this.activeServer = electedActive;
+      this.notifyAll();
+    }
   }
 
   @Override
-  public void waitForPassive() throws Exception {
-    // Do nothing - the restart brings up the active, immediately.
+  public synchronized void startLastTerminatedServer() throws Exception {
+    try {
+      PassthroughServer lastTerminatedServer = this.terminatedServersInOrder.pop();
+      if(this.activeServer != null) {
+        boolean isActive = false;
+        boolean shouldStorageLoaded = false;
+        lastTerminatedServer.start(isActive, shouldStorageLoaded);
+        this.activeServer.attachDownstreamPassive(lastTerminatedServer);
+      } else {
+        boolean isActive = true;
+        boolean shouldStorageLoaded = false;
+        lastTerminatedServer.start(isActive, shouldStorageLoaded);
+
+        attachPassivesToActive(lastTerminatedServer);
+
+        PassthroughServer prevActive = PassthroughServerRegistry.getSharedInstance().registerServer(this.stripeName, lastTerminatedServer);
+        Assert.assertTrue(prevActive == null);
+
+        this.activeServer = lastTerminatedServer;
+        this.notifyAll();
+      }
+    } catch (EmptyStackException e) {
+      throw new IllegalStateException("There are no terminated servers to start");
+    }
+  }
+
+
+  @Override
+  public synchronized void waitForActive() throws Exception {
+    while (this.activeServer == null) {
+      this.wait();
+    }
+  }
+
+  @Override
+  public synchronized void waitForPassive() throws Exception {
+    // we sync passives during the active election itself, so just wait on same state
+    while (this.activeServer == null) {
+      this.wait();
+    }
   }
 
   @Override
@@ -78,11 +200,63 @@ public class PassthroughClusterControl implements IClusterControl {
 
   @Override
   public void tearDown() {
-    this.originalActiveServer.stop();
-    if (null != this.originalPassiveServer) {
-      this.originalPassiveServer.stop();
+    for (PassthroughServer passthroughServer : passthroughServers) {
+      // don't stop twice
+      if(!stoppedPassthroughServers.contains(passthroughServer)) {
+        passthroughServer.stop();
+      }
     }
     PassthroughServer removedServer = PassthroughServerRegistry.getSharedInstance().unregisterServer(this.stripeName);
-    Assert.assertTrue(this.originalActiveServer == removedServer);
+    Assert.assertTrue(this.activeServer == removedServer);
   }
+
+  private synchronized void bootstrapCluster() {
+    Assert.assertTrue(this.activeServer == null);
+
+    final PassthroughServer electedActive = electActive();
+
+    boolean isActive = true;
+    boolean shouldStorageLoaded = false;
+
+    electedActive.start(isActive, shouldStorageLoaded);
+    for (PassthroughServer passthroughServer : passthroughServers) {
+      if(!electedActive.equals(passthroughServer)) {
+        passthroughServer.start(!isActive, shouldStorageLoaded);
+      }
+    }
+    attachPassivesToActive(electedActive);
+
+    PassthroughServer prevActive = PassthroughServerRegistry.getSharedInstance().registerServer(this.stripeName, electedActive);
+    Assert.assertTrue(prevActive == null);
+
+    this.activeServer = electedActive;
+    this.notifyAll();
+  }
+
+  private PassthroughServer electActive() {
+    // Create eligible servers list by excluding stopped servers
+    List<PassthroughServer> eligibleServers = new ArrayList<PassthroughServer>();
+    for (PassthroughServer passthroughServer : passthroughServers) {
+      if(!stoppedPassthroughServers.contains(passthroughServer)) {
+        eligibleServers.add(passthroughServer);
+      }
+    }
+
+    PassthroughServer activeServer = null;
+    if(eligibleServers.size() > 0) {
+      int random = (int) (Math.random() * eligibleServers.size());
+      activeServer = eligibleServers.get(random);
+    }
+
+    return activeServer;
+  }
+
+  private void attachPassivesToActive(PassthroughServer activeServer) {
+    for (PassthroughServer passthroughServer : passthroughServers) {
+      if(!stoppedPassthroughServers.contains(passthroughServer) && !activeServer.equals(passthroughServer)) {
+        activeServer.attachDownstreamPassive(passthroughServer);
+      }
+    }
+  }
+
 }


### PR DESCRIPTION

This PR adds support for multiple passives in passthrough framework

- PasshtroughClusterControl controls server start/stop and active transition 
- Removes strong coupling between active and passive 
- Adds crashActive method to IClusterControl to test passive transition 