### PR TITLE
Enabling IClientTestEnvironment use in passthrough

### DIFF
--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTestHelpers.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/PassthroughTestHelpers.java
@@ -18,8 +18,6 @@
  */
 package org.terracotta.passthrough;
 
-import java.util.UUID;
-
 
 /**
  * Used for setting up IClusterControl instances to wrap test cluster configurations, based on the passthrough classes.
@@ -32,12 +30,11 @@ public class PassthroughTestHelpers {
   /**
    * Creates a cluster consisting only of a single server in active state.
    * 
+   * @param stripeName The unique name for this stripe.
    * @param initializer The callback to handle initialization of the server.
    * @return A control object to use for interacting with the cluster.
    */
-  public static IClusterControl createActiveOnly(ServerInitializer initializer) {
-    // We will synthesize a unique name for this stripe.
-    String stripeName = UUID.randomUUID().toString();
+  public static IClusterControl createActiveOnly(String stripeName, ServerInitializer initializer) {
     boolean activeMode = true;
     PassthroughServer activeServer = intializeOneServer(initializer, activeMode);
     PassthroughServer passiveServer = null;
@@ -47,12 +44,11 @@ public class PassthroughTestHelpers {
   /**
    * Creates a cluster consisting only of 2 servers configured as 1 stripe:  an active and a passive.
    * 
+   * @param stripeName The unique name for this stripe.
    * @param initializer The callback to handle initialization of both servers, called on each.
    * @return A control object to use for interacting with the cluster.
    */
-  public static IClusterControl createActivePassive(ServerInitializer initializer) {
-    // We will synthesize a unique name for this stripe.
-    String stripeName = UUID.randomUUID().toString();
+  public static IClusterControl createActivePassive(String stripeName, ServerInitializer initializer) {
     boolean activeMode = true;
     PassthroughServer activeServer = intializeOneServer(initializer, activeMode);
     PassthroughServer passiveServer = intializeOneServer(initializer, !activeMode);

--- a/entity-test-lib/src/main/java/org/terracotta/passthrough/SimpleClientTestEnvironment.java
+++ b/entity-test-lib/src/main/java/org/terracotta/passthrough/SimpleClientTestEnvironment.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.passthrough;
+
+
+/**
+ * The simplest implementation of IClientTestEnvironment:  all data is passed in as read-only, at construction time.
+ */
+public class SimpleClientTestEnvironment implements IClientTestEnvironment {
+  private final String clusterUri;
+  private final int totalClientCount;
+  private final int thisClientIndex;
+
+  public SimpleClientTestEnvironment(String clusterUri, int totalClientCount, int thisClientIndex) {
+    this.clusterUri = clusterUri;
+    this.totalClientCount = totalClientCount;
+    this.thisClientIndex = thisClientIndex;
+  }
+
+  @Override
+  public String getClusterUri() {
+    return this.clusterUri;
+  }
+
+  @Override
+  public int getTotalClientCount() {
+    return this.totalClientCount;
+  }
+
+  @Override
+  public int getThisClientIndex() {
+    return this.thisClientIndex;
+  }
+}


### PR DESCRIPTION
* Adding a very simple IClientTestEnvironment implementation:  This one can be used by passthrough tests
* StripeName should be passed in to the helpers:  This means that the stripe name can be used to generate the cluster URI for the IClientTestEnvironment