### PR TITLE
Fix #127 - Add support to introspect EntityExceptions data

### DIFF
--- a/connection-api/src/main/java/org/terracotta/exception/EntityAlreadyExistsException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/EntityAlreadyExistsException.java
@@ -35,4 +35,15 @@ public class EntityAlreadyExistsException extends EntityException {
   public EntityAlreadyExistsException(String className, String entityName) {
     super(className, entityName, "already exists", null);
   }
+
+  /**
+   * Creates the exception instance describing the given type-name pair along with underlying cause of this exception
+   *
+   * @param className The name of the entity type
+   * @param entityName The name of the entity instance
+   * @param cause underlying cause of this exception
+   */
+  public EntityAlreadyExistsException(String className, String entityName, Throwable cause) {
+    super(className, entityName, "already exists", cause);
+  }
 }

--- a/connection-api/src/main/java/org/terracotta/exception/EntityException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/EntityException.java
@@ -26,6 +26,21 @@ package org.terracotta.exception;
  */
 public abstract class EntityException extends Exception {
   private static final long serialVersionUID = 1L;
+  private final String className;
+  private final String entityName;
+  private final String description;
+
+  public String getClassName() {
+    return className;
+  }
+
+  public String getEntityName() {
+    return entityName;
+  }
+
+  public String getDescription() {
+    return description;
+  }
 
   /**
    * All of these exception types have a specific description and refer to a type and name pair.
@@ -37,5 +52,8 @@ public abstract class EntityException extends Exception {
    */
   protected EntityException(String className, String entityName, String description, Throwable cause) {
     super("Entity: " + className + ":" + entityName + " " + description, cause);
+    this.className = className;
+    this.entityName = entityName;
+    this.description = description;
   }
 }

--- a/connection-api/src/main/java/org/terracotta/exception/EntityNotFoundException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/EntityNotFoundException.java
@@ -35,4 +35,14 @@ public class EntityNotFoundException extends EntityException {
   public EntityNotFoundException(String className, String entityName) {
     super(className, entityName, "not found", null);
   }
+  /**
+   * Creates the exception instance describing the given type-name pair along with underlying cause of this exception
+   *
+   * @param className The name of the entity type
+   * @param entityName The name of the entity instance
+   * @param cause underlying cause of this exception
+   */
+  public EntityNotFoundException(String className, String entityName, Throwable cause) {
+    super(className, entityName, "not found", cause);
+  }
 }

--- a/connection-api/src/main/java/org/terracotta/exception/EntityNotProvidedException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/EntityNotProvidedException.java
@@ -35,4 +35,15 @@ public class EntityNotProvidedException extends EntityException {
   public EntityNotProvidedException(String className, String entityName) {
     super(className, entityName, "no provider found for class", null);
   }
+
+  /**
+   * Creates the exception instance describing the given type-name pair along with underlying cause of this exception
+   *
+   * @param className The name of the entity type
+   * @param entityName The name of the entity instance
+   * @param cause underlying cause of this exception
+   */
+  public EntityNotProvidedException(String className, String entityName, Throwable cause) {
+    super(className, entityName, "no provider found for class", cause);
+  }
 }

--- a/connection-api/src/main/java/org/terracotta/exception/EntityVersionMismatchException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/EntityVersionMismatchException.java
@@ -27,6 +27,8 @@ package org.terracotta.exception;
  */
 public class EntityVersionMismatchException extends EntityException {
   private static final long serialVersionUID = 1L;
+  private final long expectedVersion;
+  private final long attemptedVersion;
 
   /**
    * Creates the exception instance describing the given type-name pair along with a description of the version mismatch.
@@ -38,5 +40,31 @@ public class EntityVersionMismatchException extends EntityException {
    */
   public EntityVersionMismatchException(String className, String entityName, long expectedVersion, long attemptedVersion) {
     super(className, entityName, "version mismatch (expected " + expectedVersion + " but attempted " + attemptedVersion + ")", null);
+    this.expectedVersion = expectedVersion;
+    this.attemptedVersion = attemptedVersion;
+  }
+
+  /**
+   * Creates the exception instance describing the given type-name pair along with a description of the version
+   * mismatch and underlying cause of this exception
+   *
+   * @param className The name of the entity type
+   * @param entityName The name of the entity instance
+   * @param expectedVersion The version of the actual entity instance
+   * @param attemptedVersion The version the client tried to use, which was incorrect
+   * @param cause underlying cause of this exception
+   */
+  public EntityVersionMismatchException(String className, String entityName, long expectedVersion, long attemptedVersion, Throwable cause) {
+    super(className, entityName, "version mismatch (expected " + expectedVersion + " but attempted " + attemptedVersion + ")", cause);
+    this.expectedVersion = expectedVersion;
+    this.attemptedVersion = attemptedVersion;
+  }
+
+  public long getExpectedVersion() {
+    return expectedVersion;
+  }
+
+  public long getAttemptedVersion() {
+    return attemptedVersion;
   }
 }

--- a/connection-api/src/main/java/org/terracotta/exception/PermanentEntityException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/PermanentEntityException.java
@@ -34,4 +34,17 @@ public class PermanentEntityException extends EntityNotFoundException {
   public PermanentEntityException(String className, String entityName) {
     super(className, entityName);
   }
+
+  /**
+   * Creates a new instance of <code>PermanentEntityException</code> along with underlying cause but without
+   * detail message.  This exception is thrown when a client attempts to delete a
+   * permanent entity created on the server.
+   *
+   * @param className class of the entity that was being deleted
+   * @param entityName name of the entity being deleted
+   * @param cause underlying cause of this exception
+   */
+  public PermanentEntityException(String className, String entityName, Throwable cause) {
+    super(className, entityName, cause);
+  }
 }


### PR DESCRIPTION
This PR adds
- support to introspect EntityExceptions data
- a constructor to set cause for EntityAlreadyExistsException, EntityNotFoundException, EntityNotProvidedException, EntityVersionMismatchException and PermanentEntityException