### PR TITLE
Fix #134: Added IMonitoringProducer.pushBestEffortsData

### DIFF
--- a/standard-cluster-services/src/main/java/org/terracotta/monitoring/IMonitoringProducer.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/monitoring/IMonitoringProducer.java
@@ -28,4 +28,19 @@ public interface IMonitoringProducer {
    * @return True if the node was removed.  False if it or a parent couldn't be found.
    */
   public boolean removeNode(String[] parents, String name);
+
+  /**
+   * Makes a best-efforts attempt to push named data to the interface.  This method differs from the add/remove node methods in
+   *  that the implementation is allowed to drop, ignore, or overwrite the data at any time.
+   * This interface is more appropriate for information such as statistics or other sampling information which may be dropped
+   *  if the system is busy or otherwise saturated.
+   * The implementation is free to impose whatever limiting heuristics it desires, meaning that the limiting may be based on
+   *  storage size, element count, staleness before send, or any other approach.  Additionally, the limit may be applied
+   *  globally or on a per-name basis.
+   * 
+   * @param name A name given to identify the data.  An implementation may use this as its limiting heuristic, to ensure that
+   *  infrequent data is not disproportionately over-written by very frequent data.
+   * @param data The object to push.
+   */
+  public void pushBestEffortsData(String name, Object data); 
 }


### PR DESCRIPTION
-this provides a mechanism for a proder of monitoring data to rapidly send this data through a lower-overhead, less reliable channel
-the definition of the reliability of this mechanism is left up to the implementation

NOTE:  The implementation of #135 will be made in a different PR since it has an impact on some internal types which will require a little more testing.  It will likely end up being posted before the next release is cut, though.