### PR TITLE
Fix #135: IMonitoringProducer values must be Serializable

### DIFF
--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformClientFetchedEntity.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformClientFetchedEntity.java
@@ -18,18 +18,29 @@
  */
 package org.terracotta.monitoring;
 
+import java.io.Serializable;
+
 import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 
 
 /**
  * A type which describes the connection between a client and an entity, created by a fetch.
+ * 
+ * WARNING:  The clientDescriptor is marked as transient since it can't be meaningfully deserialized and the cases where this
+ *  object will be used are also cases where it won't be serialized.  Be careful of using this object in these other cases.
  */
 @CommonComponent
-public class PlatformClientFetchedEntity {
-  public final String clientIdentifier;
-  public final String entityIdentifier;
-  public final ClientDescriptor clientDescriptor;
+public class PlatformClientFetchedEntity implements Serializable {
+  private static final long serialVersionUID = 4741752382657834201L;
+
+  public String clientIdentifier;
+  public String entityIdentifier;
+  public transient ClientDescriptor clientDescriptor;
+
+  public PlatformClientFetchedEntity() {
+    // For Serializable.
+  }
 
   public PlatformClientFetchedEntity(String clientIdentifier, String entityIdentifier, ClientDescriptor clientDescriptor) {
     this.clientIdentifier = clientIdentifier;
@@ -45,5 +56,25 @@ public class PlatformClientFetchedEntity {
     sb.append(", entityIdentifier='").append(entityIdentifier).append('\'');
     sb.append('}');
     return sb.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return this.clientIdentifier.hashCode()
+        ^ this.entityIdentifier.hashCode()
+        ^ this.clientDescriptor.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean doesMatch = (this == other);
+    if (!doesMatch && (null != other) && (getClass() == other.getClass()))
+    {
+      final PlatformClientFetchedEntity that = (PlatformClientFetchedEntity) other;
+      doesMatch = this.clientIdentifier.equals(that.clientIdentifier)
+          && this.entityIdentifier.equals(that.entityIdentifier)
+          && (((null == this.clientDescriptor) && (null == that.clientDescriptor)) || this.clientDescriptor.equals(that.clientDescriptor));
+    }
+    return doesMatch;
   }
 }

--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformConnectedClient.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformConnectedClient.java
@@ -18,6 +18,7 @@
  */
 package org.terracotta.monitoring;
 
+import java.io.Serializable;
 import java.net.InetAddress;
 
 import com.tc.classloader.CommonComponent;
@@ -27,14 +28,20 @@ import com.tc.classloader.CommonComponent;
  * A type which describes a client connected to the server.
  */
 @CommonComponent
-public class PlatformConnectedClient {
-  public final InetAddress localAddress;
-  public final int localPort;
-  public final InetAddress remoteAddress;
-  public final int remotePort;
-  public final long clientPID;
-  public final String uuid;
-  public final String name;
+public class PlatformConnectedClient implements Serializable {
+  private static final long serialVersionUID = -8750564835447846768L;
+
+  public InetAddress localAddress;
+  public int localPort;
+  public InetAddress remoteAddress;
+  public int remotePort;
+  public long clientPID;
+  public String uuid;
+  public String name;
+
+  public PlatformConnectedClient() {
+    // For Serializable.
+  }
 
   public PlatformConnectedClient(String uuid, String name, InetAddress localAddress, int localPort, InetAddress remoteAddress, int remotePort, long clientPID) {
     this.uuid = uuid;
@@ -58,5 +65,33 @@ public class PlatformConnectedClient {
     sb.append(", name='").append(name).append('\'');
     sb.append('}');
     return sb.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return this.localAddress.hashCode()
+        ^ localPort
+        ^ this.remoteAddress.hashCode()
+        ^ remotePort
+        ^ (int)clientPID
+        ^ this.uuid.hashCode()
+        ^ this.name.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean doesMatch = (this == other);
+    if (!doesMatch && (null != other) && (getClass() == other.getClass()))
+    {
+      final PlatformConnectedClient that = (PlatformConnectedClient) other;
+      doesMatch = this.localAddress.equals(that.localAddress)
+          && (this.localPort == that.localPort)
+          && this.remoteAddress.equals(that.remoteAddress)
+          && (this.remotePort == that.remotePort)
+          && (this.clientPID == that.clientPID)
+          && this.uuid.equals(that.uuid)
+          && this.name.equals(that.name);
+    }
+    return doesMatch;
   }
 }

--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformEntity.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformEntity.java
@@ -18,6 +18,8 @@
  */
 package org.terracotta.monitoring;
 
+import java.io.Serializable;
+
 import com.tc.classloader.CommonComponent;
 
 
@@ -25,10 +27,16 @@ import com.tc.classloader.CommonComponent;
  * A type which describes an entity in the stripe.
  */
 @CommonComponent
-public class PlatformEntity {
-  public final String typeName;
-  public final String name;
-  public final boolean isActive;
+public class PlatformEntity implements Serializable {
+  private static final long serialVersionUID = -2907606444970217901L;
+
+  public String typeName;
+  public String name;
+  public boolean isActive;
+
+  public PlatformEntity() {
+    // For Serializable.
+  }
 
   public PlatformEntity(String typeName, String name, boolean isActive) {
     this.typeName = typeName;
@@ -44,5 +52,25 @@ public class PlatformEntity {
     sb.append(", name='").append(name).append('\'');
     sb.append('}');
     return sb.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return this.typeName.hashCode()
+        ^ this.name.hashCode()
+        ^ (isActive ? 0x1 : 0x0);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean doesMatch = (this == other);
+    if (!doesMatch && (null != other) && (getClass() == other.getClass()))
+    {
+      final PlatformEntity that = (PlatformEntity) other;
+      doesMatch = this.typeName.equals(that.typeName)
+          && this.name.equals(that.name)
+          && (this.isActive == that.isActive);
+    }
+    return doesMatch;
   }
 }

--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformServer.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformServer.java
@@ -18,22 +18,28 @@
  */
 package org.terracotta.monitoring;
 
+import java.io.Serializable;
+
 import com.tc.classloader.CommonComponent;
 
-/**
- *
- */
+
 @CommonComponent
-public class PlatformServer {
-  private final String serverName;
-  private final String hostName;
-  private final String hostAddress;
-  private final String bindAddress;
-  private final int bindPort;
-  private final int groupPort;
-  private final String version;
-  private final String build;
-  private final long startTime;
+public class PlatformServer implements Serializable {
+  private static final long serialVersionUID = 6603745920231301851L;
+
+  private String serverName;
+  private String hostName;
+  private String hostAddress;
+  private String bindAddress;
+  private int bindPort;
+  private int groupPort;
+  private String version;
+  private String build;
+  private long startTime;
+
+  public PlatformServer() {
+    // For Serializable.
+  }
 
   public PlatformServer(String serverName, String host, String hostAddress, String bindAddress, int bindPort, int groupPort, String version, String build, long startTime) {
     this.serverName = serverName;
@@ -90,4 +96,35 @@ public class PlatformServer {
         ", groupPort=" + groupPort + ", version=" + version + ", build=" + build + ", startTime=" + startTime + '}';
   }
 
+  @Override
+  public int hashCode() {
+    return this.serverName.hashCode()
+        ^ this.hostName.hashCode()
+        ^ this.hostAddress.hashCode()
+        ^ this.bindAddress.hashCode()
+        ^ bindPort
+        ^ groupPort
+        ^ this.version.hashCode()
+        ^ this.build.hashCode()
+        ^ (int)startTime;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean doesMatch = (this == other);
+    if (!doesMatch && (null != other) && (getClass() == other.getClass()))
+    {
+      final PlatformServer that = (PlatformServer) other;
+      doesMatch = this.serverName.equals(that.serverName)
+          && this.hostName.equals(that.hostName)
+          && this.hostAddress.equals(that.hostAddress)
+          && this.bindAddress.equals(that.bindAddress)
+          && (this.bindPort == that.bindPort)
+          && (this.groupPort == that.groupPort)
+          && this.version.equals(that.version)
+          && this.build.equals(that.build)
+          && (this.startTime == that.startTime);
+    }
+    return doesMatch;
+  }
 }

--- a/monitoring-support/src/main/java/org/terracotta/monitoring/ServerState.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/ServerState.java
@@ -18,13 +18,19 @@
  */
 package org.terracotta.monitoring;
 
-/**
- *
- */
-public class ServerState {
-  private final String state;
-  private final long timestamp;
-  private final long activate;
+import java.io.Serializable;
+
+
+public class ServerState implements Serializable {
+  private static final long serialVersionUID = 1207854911088611229L;
+
+  private String state;
+  private long timestamp;
+  private long activate;
+
+  public ServerState() {
+    // For Serializable.
+  }
 
   public ServerState(String state, long timestamp, long activate) {
     this.state = state;
@@ -47,5 +53,25 @@ public class ServerState {
   @Override
   public String toString() {
     return "ServerState{" + "state=" + state + ", timestamp=" + timestamp + ", activateTime=" + activate +  '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return this.state.hashCode()
+        ^ (int)timestamp
+        ^ (int)activate;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    boolean doesMatch = (this == other);
+    if (!doesMatch && (null != other) && (getClass() == other.getClass()))
+    {
+      final ServerState that = (ServerState) other;
+      doesMatch = this.state.equals(that.state)
+          && (this.timestamp == that.timestamp)
+          && (this.activate == that.activate);
+    }
+    return doesMatch;
   }
 }

--- a/standard-cluster-services/src/main/java/org/terracotta/monitoring/IMonitoringProducer.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/monitoring/IMonitoringProducer.java
@@ -1,11 +1,15 @@
 package org.terracotta.monitoring;
 
+import java.io.Serializable;
+
 import com.tc.classloader.CommonComponent;
 
 
 /**
  * The interface exposed by a monitoring service, allowing entities to push statistics and structured data which can be
  * consumed by an external component (attached to the other side of the service, using some more specialized interface).
+ * 
+ * Note that the values used in these methods must be Serializable since the implementation may need to send them over a wire.
  */
 @CommonComponent
 public interface IMonitoringProducer {
@@ -18,7 +22,7 @@ public interface IMonitoringProducer {
    * @param value The value to set for the new node.
    * @return True if the node was created/replaced.  False if a parent couldn't be found.
    */
-  public boolean addNode(String[] parents, String name, Object value);
+  public boolean addNode(String[] parents, String name, Serializable value);
 
   /**
    * Removes a node from the internal data registry tree.
@@ -42,5 +46,5 @@ public interface IMonitoringProducer {
    *  infrequent data is not disproportionately over-written by very frequent data.
    * @param data The object to push.
    */
-  public void pushBestEffortsData(String name, Object data); 
+  public void pushBestEffortsData(String name, Serializable data); 
 }


### PR DESCRIPTION
-this will ensure that future concerns of how to communicate monitoring data between active and passive servers will be possible
-this also required that the standard types defined in monitoring-support be made serializable
-of specific note, this means that PlatformClientFetchedEntity's ClientDescriptor had to be marked transient, since it can't be meaningfully deserialized (it is akin to deserializing a file descriptor).  These should appear in cases where this would matter, however, as these are not created by the passive
-for testing reasons, this also required the addition of hashCode() and equals() methods to these types (with the assumption that only this ClientDescriptor field can be null and only due to its transient nature)