### PR TITLE
(DISCUSS) Fix #144:  Added clarification regarding concurrency keys running life-cycle calls

### DIFF
--- a/entity-server-api/src/main/java/org/terracotta/entity/CommonServerEntity.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/CommonServerEntity.java
@@ -22,22 +22,37 @@ package org.terracotta.entity;
 /**
  * The methods common to both active and passive entities.
  * @param <M> The high-level message type used by the active and passive server-side entities.  This type is created by the
- * implementation's MessageCodec and also read by the ConcurrencyStrategy.
+ *  implementation's MessageCodec and also read by the ConcurrencyStrategy.
  * @param <R> The high-level message type returned by invoke calls on the active entity.
  */
-public interface CommonServerEntity<M extends EntityMessage, R extends EntityResponse> {  
+public interface CommonServerEntity<M extends EntityMessage, R extends EntityResponse> {
   /**
-   * Called when a client asks that an entity be explicitly created.
+   * <p>Called when a client asks that an entity be explicitly created.  Also called at the very beginning of passive sync of
+   *  the entity, asking it to be created for the first time.</p>
+   * <p>This is distinct from cases such as restart or fail-over when the object will receive a loadExisting() call,
+   *  instead.</p>
+   * <p>Note that this call is made on the {@link ConcurrencyStrategy#MANAGEMENT_KEY}, meaning that it is serialized with
+   *  respect to all other messages enqueued for the entity.</p>
    */
   void createNew();
   
   /**
-   * Called when starting a server from a persistent state and the entity is expected to already be known to the server.
+   * <p>Called when starting a server from a persistent state and the entity is expected to already be known to the
+   *  server.</p>
+   * <p>Specifically, this refers to situations such as a restart or fail-over.  A given entity will always receive a single
+   *  createNew() call but can receive any number of loadExisting() calls, in response to server life-cycle.</p>
+   * <p>Note that this call is made on the {@link ConcurrencyStrategy#MANAGEMENT_KEY}, meaning that it is serialized with
+   *  respect to all other messages enqueued for the entity.</p>
    */
   void loadExisting();
   
   /**
-   * Destroy all state associated with this entity.
+   * <p>Destroy all state associated with this entity.</p>
+   * <p>This is called in response to a client explicitly requesting that the entity be destroyed.  Other situations where
+   *  the object representing the entity may be discarded (server goes down for a restart or the server is being promoted to
+   *  active) will not result in this call.</p>
+   * <p>Note that this call is made on the {@link ConcurrencyStrategy#MANAGEMENT_KEY}, meaning that it is serialized with
+   *  respect to all other messages enqueued for the entity.</p>
    */
   void destroy();
 }

--- a/entity-server-api/src/main/java/org/terracotta/entity/ConcurrencyStrategy.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/ConcurrencyStrategy.java
@@ -88,6 +88,10 @@ public interface ConcurrencyStrategy<M extends EntityMessage> {
    * 
    * <p>The key set returned MUST NOT contain either MANAGEMENT_KEY or UNIVERSAL_KEY.</p>
    * 
+   * <p>Note that the keys are synchronized in the order returned by the returned set's {@link Set#iterator()}, one at a
+   * time.  This means that an ordered set can be used in order to ensure that a specific key finishes synchronizing before
+   * any others start, for example.</p>
+   * 
    * @return The set of concurrency keys to synchronize to the passive.
    */
   Set<Integer> getKeysForSynchronization();

--- a/entity-server-api/src/main/java/org/terracotta/entity/PassiveServerEntity.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/PassiveServerEntity.java
@@ -16,46 +16,57 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package org.terracotta.entity;
 
 
 /**
- * The methods specifically supported by passive entities.  Note that a passive doesn't know anything about
- *  connected clients, nor can it return data to them.
- * Note that passive entities have no invoke response but we still accept the generic R so that accessors of the codec will
- * see a consistent type landscape.
+ * <p>The methods specifically supported by passive entities.  Note that a passive doesn't know anything about
+ *  connected clients, nor can it return data to them.</p>
+ * <p>Note that passive entities have no invoke response but we still accept the generic R so that accessors of the codec
+ *  will see a consistent type landscape.</p>
  */
 public interface PassiveServerEntity<M extends EntityMessage, R extends EntityResponse> extends CommonServerEntity<M, R> {
   /**
-   * Invoke a call on the given entity.  Note that passive entities can't return data to the client.
-   * This method is called both in the cases of normal client->server method invocation but also in the case of
-   * server->server passive synchronization.
+   * <p>Invoke a call on the given entity.  Note that passive entities can't return data to the client.</p>
+   * <p>This method is called both in the cases of normal client->server method invocation but also in the case of
+   *  server->server passive synchronization.</p>
+   * <p>Note that the thread used to make this call is determined by consulting the entity's ConcurrencyStrategy so it may be
+   *  called concurrently with other invokes.</p>
+   * <p>A note about passive synchronization messages:  When the active is given the opportunity to synchronize the data
+   *  under a given key, the messages it creates and sends for synchronization will be executed in that key, on the passive,
+   *  via this invoke() entry-point.</p>
    *
    * @param message The message from a client or upstream active server
    */
   void invoke(M message);
 
   /**
-   * Called on MANAGEMENT_KEY to notify the receiver that it is about to start receiving synchronization messages.
+   * <p>Called on {@link ConcurrencyStrategy#MANAGEMENT_KEY} to notify the receiver that it is about to start receiving
+   *  synchronization messages.</p>
+   * <p>Note that this is called after createNew().</p>
    */
   void startSyncEntity();
 
   /**
-   * Called on MANAGEMENT_KEY to notify the receiver synchronization is complete and it will see no more synchronization
-   * messages.
+   * Called on {@link ConcurrencyStrategy#MANAGEMENT_KEY} to notify the receiver synchronization is complete and it will see
+   *  no more synchronization messages.
    */
   void endSyncEntity();
 
   /**
-   * Called on concurrencyKey to notify the receiver that it is about to start receiving synchronization messages on this
-   * key.
+   * <p>Called on concurrencyKey to notify the receiver that it is about to start receiving synchronization messages on this
+   *  key.</p>
+   * <p>To clarify:  the concurrencyKey is both the argument (so the entity can logically act on it) but is also the key
+   *  where this call is executed.</p>
    */
   void startSyncConcurrencyKey(int concurrencyKey);
 
   /**
-   * Called on concurrencyKey to notify the receiver that synchronization of this key is complete and no more
-   * synchronization messages will be received on that key.
+   * <p>Called on concurrencyKey to notify the receiver that synchronization of this key is complete and no more
+   *  synchronization messages will be received on that key.</p>
+   * <p>Note that no invokes will be made on this key until this method has been called.</p>
+   * <p>To clarify:  the concurrencyKey is both the argument (so the entity can logically act on it) but is also the key
+   *  where this call is executed.</p>
    */
   void endSyncConcurrencyKey(int concurrencyKey);
 }


### PR DESCRIPTION
Posted as a starting-point for discussing these JavaDoc changes.  Once we feel as though this change is complete, we can merge it (potentially requiring some rebase since there are related discussions to start, as well).