### PR TITLE
(DISCUSS) Create IStripeMonitoring interface for receiving monitoring data from a stripe

### DIFF
--- a/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformMonitoringConstants.java
+++ b/monitoring-support/src/main/java/org/terracotta/monitoring/PlatformMonitoringConstants.java
@@ -33,10 +33,6 @@ public class PlatformMonitoringConstants {
    */
   public static final String PLATFORM_ROOT_NAME = "platform";
   /**
-   * The name of the node in the tree which is the parent to all nodes representing connected servers.
-   */
-  public static final String SERVERS_ROOT_NAME = "servers";
-  /**
    * The name of the node in the tree which is the parent to all nodes representing connected clients.
    */
   public static final String CLIENTS_ROOT_NAME = "clients";
@@ -49,7 +45,8 @@ public class PlatformMonitoringConstants {
    */
   public static final String FETCHED_ROOT_NAME = "fetched";
   /**
-   * The name of the node in the tree which stores the name of the server's current state.
+   * The name of the node in the tree which stores the ServerState instance.
+   * This is a direct child of PLATFORM_ROOT_NAME.
    */
   public static final String STATE_NODE_NAME = "state";
 
@@ -57,10 +54,6 @@ public class PlatformMonitoringConstants {
    * The path of the platform node, for manipulating its children.
    */
   public static final String[] PLATFORM_PATH = {PLATFORM_ROOT_NAME};
-  /**
-   * The path of the platform's clients node, for manipulating its children.
-   */
-  public static final String[] SERVERS_PATH = {PLATFORM_ROOT_NAME, SERVERS_ROOT_NAME};
   /**
    * The path of the platform's clients node, for manipulating its children.
    */

--- a/standard-cluster-services/pom.xml
+++ b/standard-cluster-services/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>packaging-support</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>monitoring-support</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/standard-cluster-services/src/main/java/org/terracotta/monitoring/IStripeMonitoring.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/monitoring/IStripeMonitoring.java
@@ -6,36 +6,37 @@ import com.tc.classloader.CommonComponent;
 
 
 /**
- * The interface exposed by a monitoring service, allowing entities to push statistics and structured data which can be
- *  consumed by an external component.
+ * The interface which must be implemented by a monitoring component in order to receive the data entities passed into
+ *  IMonitoringProducer, on a server within the stripe.
  * 
- * The implementation of this interface is provided by the server implementation, itself.  A monitoring component must
- *  provide an IStripeMonitoring implementation to receive the data passed into this interface.
+ * Note that only the implementation on the current active server will receive this data but it will receive the data from
+ *  the entire stripe.
  * 
- * Note that the values used in these methods must be Serializable since the implementation may need to send them over a
- *  wire.
+ * Note that the values used in these methods are Serializable since they may have come over the wire.
  */
 @CommonComponent
-public interface IMonitoringProducer {
+public interface IStripeMonitoring {
   /**
    * Adds a node to the internal data registry tree or replaces an existing one.
    * By default, new nodes have no children.
    * 
+   * @param sender The description of the server where the call originated.
    * @param parents The parent node names, starting from the root.
    * @param name The name of the node to create or replace.
    * @param value The value to set for the new node.
    * @return True if the node was created/replaced.  False if a parent couldn't be found.
    */
-  public boolean addNode(String[] parents, String name, Serializable value);
+  public boolean addNode(PlatformServer sender, String[] parents, String name, Serializable value);
 
   /**
    * Removes a node from the internal data registry tree.
    * 
+   * @param sender The description of the server where the call originated.
    * @param parents The parent node names, starting from the root.
    * @param name The name of the node to remove.
    * @return True if the node was removed.  False if it or a parent couldn't be found.
    */
-  public boolean removeNode(String[] parents, String name);
+  public boolean removeNode(PlatformServer sender, String[] parents, String name);
 
   /**
    * Makes a best-efforts attempt to push named data to the interface.  This method differs from the add/remove node methods
@@ -46,9 +47,10 @@ public interface IMonitoringProducer {
    *  storage size, element count, staleness before send, or any other approach.  Additionally, the limit may be applied
    *  globally or on a per-name basis.
    * 
+   * @param sender The description of the server where the call originated.
    * @param name A name given to identify the data.  An implementation may use this as its limiting heuristic, to ensure that
    *  infrequent data is not disproportionately over-written by very frequent data.
    * @param data The object to push.
    */
-  public void pushBestEffortsData(String name, Serializable data); 
+  public void pushBestEffortsData(PlatformServer sender, String name, Serializable data); 
 }

--- a/standard-cluster-services/src/main/java/org/terracotta/monitoring/IStripeMonitoring.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/monitoring/IStripeMonitoring.java
@@ -17,6 +17,34 @@ import com.tc.classloader.CommonComponent;
 @CommonComponent
 public interface IStripeMonitoring {
   /**
+   * Called when a server first becomes active to notify its IStripeMonitoring implementation that it will now start to
+   *  receive the other calls in this interface.  The PlatformServer representing itself is provided so that it can identify
+   *  the calls which are locally-originating.
+   * NOTE:  This is only ever called on the consumerID 0 instance.
+   * 
+   * @param self The description of the active server where this call occurs.
+   */
+  public void serverDidBecomeActive(PlatformServer self);
+
+  /**
+   * Called to notify the implementation when another server has first joined the stripe, meaning that messages may start
+   *  arriving from this server.
+   * NOTE:  This is only ever called on the consumerID 0 instance.
+   * 
+   * @param server The description of the newly-arrived server.
+   */
+  public void serverDidJoinStripe(PlatformServer server);
+
+  /**
+   * Called to notify the implementation when another server has left the stripe, meaning that no more messages will be
+   *  arriving from this server and any others from it are now stale.
+   * NOTE:  This is only ever called on the consumerID 0 instance.
+   * 
+   * @param server The description of the now-departed server.
+   */
+  public void serverDidLeaveStripe(PlatformServer server);
+
+  /**
    * Adds a node to the internal data registry tree or replaces an existing one.
    * By default, new nodes have no children.
    * 


### PR DESCRIPTION
* this splits the way that monitoring data moves through the system into explicit "sender" and "receiver" components
* `IMonitoringProducer` is still used by an entity when it wants to send data to the monitoring implementation
* `IStripeMonitoring` is the new interface which must be implemented by the monitoring component in order to receive this data
* the `IStripeMonitoring` implementation will receive all monitoring data from the entire stripe, but only the instance running on the active will be given this information