### PR TITLE
[DO NOT MERGE] Message typing for Replication

### DIFF
--- a/entity-common-api/src/main/java/org/terracotta/entity/ActiveExcludedEntityMessage.java
+++ b/entity-common-api/src/main/java/org/terracotta/entity/ActiveExcludedEntityMessage.java
@@ -1,0 +1,24 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+
+package org.terracotta.entity;
+
+
+public interface ActiveExcludedEntityMessage extends EntityMessage {
+}

--- a/entity-common-api/src/main/java/org/terracotta/entity/Execution.java
+++ b/entity-common-api/src/main/java/org/terracotta/entity/Execution.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.entity;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ */
+@Target( ElementType.TYPE )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface Execution {
+  public static enum ServerState {ACTIVE, PASSIVE};
+  public ServerState[] value();
+}

--- a/entity-common-api/src/main/java/org/terracotta/entity/PassiveExcludedEntityMessage.java
+++ b/entity-common-api/src/main/java/org/terracotta/entity/PassiveExcludedEntityMessage.java
@@ -1,0 +1,24 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+
+package org.terracotta.entity;
+
+
+public interface PassiveExcludedEntityMessage extends EntityMessage {
+}


### PR DESCRIPTION
This is for discussion only.  We should probably pick one method or the other but not both.

One method uses the type system to designate if the message is active or passive only.  The common type means run on both active and passive

```
class MyActiveMessage extends ActiveOnlyEntityMessage {  //  active only execution

}

class MyPassiveMessage extends PassiveOnlyEntityMessage {  //  passive only execution

}

class MyEnytityMessage extends EntityMessage {  // runs on both 

}
```

The other method uses annotation to convey the same information

```
@Execution(Execution.ServerState.ACTIVE)
class MyActiveMessage extends EntityMessage {  // active only 

}

@Execution(Exection.ServerState.PASSIVE) 
class MyPassiveMessage extends EntityMessage {  // passive only 

}

@Execution({Exection.ServerState.ACTIVE, Exection.ServerState.PASSIVE})
class MyEntityMessage extends EntityMessage {  //  both

}

class MyEntityMessage {  // both

}
```