### PR TITLE
Fix #157 - Add API to expose platform config

### DIFF
--- a/entity-server-api/src/main/java/org/terracotta/entity/PlatformConfiguration.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/PlatformConfiguration.java
@@ -1,0 +1,16 @@
+package org.terracotta.entity;
+
+/**
+ *
+ * API for exposing platform configuration
+ *
+ * @author vmad
+ */
+public interface PlatformConfiguration {
+  /**
+   * Gets configured name for this server
+   *
+   * @return configured server name
+   */
+  String getServerName();
+}

--- a/entity-server-api/src/main/java/org/terracotta/entity/ServiceProvider.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/ServiceProvider.java
@@ -53,10 +53,11 @@ public interface ServiceProvider {
    *  {@link #getService(long, ServiceConfiguration<T>)}.
    * 
    * @param configuration The configuration for this ServiceProvider instance.
+   * @param platformConfiguration platform configuration
    * @return True if provider has successfully been initialized with the provided configuration, false if this instance
    *  shouldn't be registered for the given configuration (it will be discarded).
    */
-  boolean initialize(ServiceProviderConfiguration configuration);
+  boolean initialize(ServiceProviderConfiguration configuration, PlatformConfiguration platformConfiguration);
 
   /**
    * Get an instance of a service from the provider.


### PR DESCRIPTION
* PlatformConfiguration exposes server name currently
* Pass PlatformConfiguration to ServiceProviders via initialize(...)