### PR TITLE
API changes entities

### DIFF
--- a/entity-server-api/pom.xml
+++ b/entity-server-api/pom.xml
@@ -30,6 +30,9 @@
 
   <groupId>org.terracotta</groupId>
   <artifactId>entity-server-api</artifactId>
+  <properties>
+    <java.build.version>1.8</java.build.version>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/entity-server-api/src/main/java/org/terracotta/entity/EntityServerService.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/EntityServerService.java
@@ -64,6 +64,30 @@ public interface EntityServerService<M extends EntityMessage, R extends EntityRe
   PassiveServerEntity<M, R> createPassiveEntity(ServiceRegistry registry, byte[] configuration);
   
   /**
+   * Reconfigure an existing entity during server execution.  Reconfigure call in the
+   * platform's entity API allows an entity to reconfigure in place, its instance in the 
+   * system.  Prior to the call of this method, the entities execution queue is flushed and 
+   * any subsequent messages are blocked until this call completes.  This call occurs only 
+   * under the MANAGEMENT_KEY concurrency key.  Implementations are allowed to either reconfigure
+   * in place and return the same instance of the entity or a new entity may be built if desired.
+   * 
+   * @param <AP> the entity type being reconfigured
+   * @param registry the service registry for the entity
+   * @param oldEntity the instance of the entity implementation being reconfigured
+   * @param configuration the new configuration of the entity
+   * @return An entity instance influenced by the new configuration
+   */
+  default <AP extends CommonServerEntity<M, R>> AP reconfigureEntity(ServiceRegistry registry, AP oldEntity, byte[] configuration) {
+    if (oldEntity instanceof PassiveServerEntity) {
+      return (AP)createPassiveEntity(registry, configuration);
+    } else if (oldEntity instanceof ActiveServerEntity) {
+      return (AP)createActiveEntity(registry, configuration);
+    } else {
+      throw new AssertionError("unknown entity type");
+    }
+  }
+  
+  /**
    * Get the concurrency strategy to be used for this server entity.
    *
    * @param configuration

--- a/entity-server-api/src/main/java/org/terracotta/entity/EntityServerService.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/EntityServerService.java
@@ -66,9 +66,24 @@ public interface EntityServerService<M extends EntityMessage, R extends EntityRe
   /**
    * Get the concurrency strategy to be used for this server entity.
    *
+   * @param configuration
    * @return concurrency strategy
    */
   ConcurrencyStrategy<M> getConcurrencyStrategy(byte[] configuration);
+  /**
+   * Get the execution strategy to be used for this server entity.  The default implementation
+   * designates that all messages will be run on both active and passive
+   *
+   * @return execution strategy
+   */
+  default ExecutionStrategy<M> getExecutionStrategy(byte[] configuration) {
+    return new ExecutionStrategy<M>() {
+      @Override
+      public ExecutionStrategy.Location getExecutionLocation(M message) {
+        return ExecutionStrategy.Location.IGNORE;
+      }
+    };
+  }
   /**
    * Gets the message codec which will be used to convert high-level {@link EntityMessage}/{@link EntityResponse}
    * to byte[] and vice-versa

--- a/entity-server-api/src/main/java/org/terracotta/entity/ExecutionStrategy.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/ExecutionStrategy.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.entity;
+
+/**
+ *  ExecutionStrategy helps the stripe determine if a particular message should 
+ *  be executed on the active server, passive server or both
+ */
+public interface ExecutionStrategy<M extends EntityMessage> {
+  enum Location {
+    ACTIVE {
+      @Override
+      public boolean runOnPassive() {
+        return false;
+      }
+    }, PASSIVE {
+      @Override
+      public boolean runOnActive() {
+        return false;
+      }
+    }, BOTH {
+
+    }, NONE {
+      @Override
+      public boolean runOnActive() {
+        return false;
+      }
+
+      @Override
+      public boolean runOnPassive() {
+        return false;
+      }
+    }, IGNORE;  // IGNORE is for internal use only
+    
+    public boolean runOnPassive() {
+      return true;
+    }
+    
+    public boolean runOnActive() {
+      return true;
+    }
+  }
+  
+  Location getExecutionLocation(M message);
+}

--- a/monitoring-support/pom.xml
+++ b/monitoring-support/pom.xml
@@ -30,8 +30,10 @@
 
   <groupId>org.terracotta</groupId>
   <artifactId>monitoring-support</artifactId>
-
-  <dependencies>
+  <properties>
+    <java.build.version>1.8</java.build.version>
+  </properties>
+ <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>packaging-support</artifactId>

--- a/standard-cluster-services/pom.xml
+++ b/standard-cluster-services/pom.xml
@@ -30,7 +30,9 @@
 
   <groupId>org.terracotta</groupId>
   <artifactId>standard-cluster-services</artifactId>
-
+  <properties>
+    <java.build.version>1.8</java.build.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>


### PR DESCRIPTION
Added reconfigure to EntityServerService so that implementors have an opportunity to transfer state of the entity to new reconfigured entity since reconfigure happens in the middle of entity execution.

Added ExecutionStrategy to deprecate `InvocationBuilder.requiresReplication()` since that call is mis-placed and mis-used by the platform.

Updated the pom files to reflect that the server is java 1.8 only.