### PR TITLE
(READY) Fix #158: Add delayed/periodic calls to IEntityMessenger

### DIFF
--- a/standard-cluster-services/src/main/java/org/terracotta/entity/IEntityMessenger.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/entity/IEntityMessenger.java
@@ -47,4 +47,45 @@ public interface IEntityMessenger {
    * @throws MessageCodecException The message could not be serialized.
    */
   void messageSelfAndDeferRetirement(EntityMessage originalMessageToDefer, EntityMessage newMessageToSchedule) throws MessageCodecException;
+
+  /**
+   * Requests that the given message be send to the entity instance after millisBeforeSend have elapsed.
+   * The message will be sent once, and may arrive late but won't arrive before millisBeforeSend have elapsed.
+   * The message will not arrive if the server restarts or the entity is destroyed before it was due.
+   * 
+   * @param message The new message to send.
+   * @param millisBeforeSend The minimum number of milliseconds which must pass before message should be delivered.
+   * @return A token to describe this delayed send which can be used to cancel it.
+   * @throws MessageCodecException The message could not be serialized.
+   */
+  ScheduledToken messageSelfAfterDelay(EntityMessage message, long millisBeforeSend) throws MessageCodecException;
+
+  /**
+   * Requests that the given message be send to the entity instance every millisBetweenSends milliseconds.
+   * The message will be sent continuously with the first arriving after millisBetweenSends and then again after each
+   *  millisBetweenSends milliseconds.  Note that drift in the actual delivery time will not change the scheduled time of
+   *  each following message delivery at N*millisBetweenSends milliseconds from when this call was made.
+   * Note that any message send may arrive late but won't arrive before N*millisBetweenSends have elapsed.
+   * This message will continue to be re-sent until it is canceled, the server restarts, or the entity is destroyed.
+   * 
+   * @param message The new message to send.
+   * @param millisBetweenSends The minimum number of milliseconds which must pass before each message should be delivered.
+   * @return A token to describe this delayed send which can be used to cancel it.
+   * @throws MessageCodecException The message could not be serialized.
+   */
+  ScheduledToken messageSelfPeriodically(EntityMessage message, long millisBetweenSends) throws MessageCodecException;
+
+  /**
+   * Called to cancel a previously scheduled delayed or periodic message.
+   * 
+   * @param token The token previously received for a scheduled message.
+   */
+  void cancelTimedMessage(ScheduledToken token);
+
+
+  /**
+   * An opaque interface used as the token type for canceling previously scheduled messages.
+   */
+  public interface ScheduledToken {
+  }
 }


### PR DESCRIPTION
-these new interfaces will allow an entity to send itself a specific message after a delay or periodically
-a ScheduledToken is provided so that these calls can be cancelled

NOTE:  This can be merged once we are ready to release.