### PR TITLE
Fix #181 - add configuration exceptions to lifecycle operations

### DIFF
--- a/connection-api/src/main/java/org/terracotta/exception/EntityConfigurationException.java
+++ b/connection-api/src/main/java/org/terracotta/exception/EntityConfigurationException.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Connection API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.exception;
+
+
+/**
+ * This specific EntityException type is thrown in cases where an exception was thrown from user code associated
+ * with the entity during a lifecycle operation.
+ */
+public class EntityConfigurationException extends EntityException {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Creates the exception instance describing the given type-name pair and the specific underlying exception from the user
+   * code.
+   * 
+   * @param className The name of the entity type
+   * @param entityName The name of the entity instance
+   * @param cause The underlying throwable thrown by the user code
+   */
+  public EntityConfigurationException(String className, String entityName, Throwable cause) {
+    super(className, entityName, "lifecycle exception: " + cause.getLocalizedMessage(), cause);
+  }
+}

--- a/entity-server-api/src/main/java/org/terracotta/entity/ConfigurationException.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/ConfigurationException.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Connection API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.entity;
+
+/**
+ *
+ */
+public class ConfigurationException extends Exception {
+  /**
+   * Creates a new instance of <code>ConfigurationException</code> without
+   * detail message.  This exception is thrown when a client attempts to delete a
+   * permanent entity created on the server.
+   * 
+   * @param description an implementation defined description of the problem
+   */
+  public ConfigurationException(String description) {
+    this(description, null);
+  }
+
+  /**
+   * Creates a new instance of <code>EntityConfigurationException</code> along with underlying cause but without
+   * detail message.  This exception is thrown when a client attempts to delete a
+   * permanent entity created on the server.
+   *
+   * @param description an implementation defined description of the problem
+   * @param cause underlying cause of this exception
+   */
+  public ConfigurationException(String description, Throwable cause) {
+    super(description, cause);
+  }
+}

--- a/entity-server-api/src/main/java/org/terracotta/entity/EntityServerService.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/EntityServerService.java
@@ -51,8 +51,9 @@ public interface EntityServerService<M extends EntityMessage, R extends EntityRe
    * @param registry registry of services provided by the server
    * @param configuration entity specific configuration object
    * @return server side entity
+   * @throws org.terracotta.entity.ConfigurationException
    */
-  ActiveServerEntity<M, R> createActiveEntity(ServiceRegistry registry, byte[] configuration);
+  ActiveServerEntity<M, R> createActiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException;
 
   /**
    * Create an instance of the specified server entity in passive mode.
@@ -60,8 +61,9 @@ public interface EntityServerService<M extends EntityMessage, R extends EntityRe
    * @param registry registry of services provided by the server
    * @param configuration entity specific configuration object
    * @return server side entity
+   * @throws org.terracotta.entity.ConfigurationException
    */
-  PassiveServerEntity<M, R> createPassiveEntity(ServiceRegistry registry, byte[] configuration);
+  PassiveServerEntity<M, R> createPassiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException;
   
   /**
    * Reconfigure an existing entity during server execution.  Reconfigure call in the
@@ -76,8 +78,9 @@ public interface EntityServerService<M extends EntityMessage, R extends EntityRe
    * @param oldEntity the instance of the entity implementation being reconfigured
    * @param configuration the new configuration of the entity
    * @return An entity instance influenced by the new configuration
+   * @throws org.terracotta.entity.ConfigurationException
    */
-  default <AP extends CommonServerEntity<M, R>> AP reconfigureEntity(ServiceRegistry registry, AP oldEntity, byte[] configuration) {
+  default <AP extends CommonServerEntity<M, R>> AP reconfigureEntity(ServiceRegistry registry, AP oldEntity, byte[] configuration) throws ConfigurationException {
     if (oldEntity instanceof PassiveServerEntity) {
       return (AP)createPassiveEntity(registry, configuration);
     } else if (oldEntity instanceof ActiveServerEntity) {


### PR DESCRIPTION
ConfigurationException added to EntityServerService so that implementations can throw on failed lifecycle operations.  The implementations of this API should report EntityConfigurationException back to the client if all nodes of a stripe agree.  If some succeed and others fail, the succeeding servers will survive and failing servers will be zapped.