### PR TITLE
Fix #196: CommonServerEntity.createNew() now throws ConfigurationException

### DIFF
--- a/entity-server-api/src/main/java/org/terracotta/entity/CommonServerEntity.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/CommonServerEntity.java
@@ -33,8 +33,9 @@ public interface CommonServerEntity<M extends EntityMessage, R extends EntityRes
    *  instead.</p>
    * <p>Note that this call is made on the {@link ConcurrencyStrategy#MANAGEMENT_KEY}, meaning that it is serialized with
    *  respect to all other messages enqueued for the entity.</p>
+   * @throws ConfigurationException If an instance cannot be created as new with the configuration it was given.
    */
-  void createNew();
+  void createNew() throws ConfigurationException;
   
   /**
    * <p>Destroy all state associated with this entity.</p>


### PR DESCRIPTION
-this allows configuration to be validated when the entity knows whether it is new or old, instead of just at the point of instantiation