### PR TITLE
Fix #198: Clarify use of EntityClientEndpoint within EntityClientService

### DIFF
--- a/connection-api/src/main/java/org/terracotta/connection/entity/Entity.java
+++ b/connection-api/src/main/java/org/terracotta/connection/entity/Entity.java
@@ -22,14 +22,18 @@ import java.io.Closeable;
 
 
 /**
- * An instance of this type represents a concrete connection to a server-side entity.  The entity always exists so long as
- * an instance of this type is open to it.  This also means that the open instance will block any attempts to delete the
- * server-side instance.
- * Therefore, close() must be called in order to release this hold on the entity.
+ * <p>An instance of this type represents a concrete connection to a server-side entity.  The entity always exists so
+ * long as an instance of this type is open to it.  This also means that the open instance will block any attempts to
+ * delete the server-side instance.</p>
+ * 
+ * <p>Therefore, {@link Entity#close()} must be called in order to release this hold on the entity.</p>
  */
 public interface Entity extends Closeable {
   /**
-   * Release this handle on the entity. The instance will be unusable after this call.
+   * <p>Release this handle on the entity. The instance will be unusable after this call.</p>
+   * 
+   * <p>Note:  The implementation is required to close its underlying {@link EntityRef} within this call so the server
+   * can be notified that the client-side reference has been released.</p>
    */
   @Override
   void close();

--- a/entity-client-api/src/main/java/org/terracotta/entity/EntityClientService.java
+++ b/entity-client-api/src/main/java/org/terracotta/entity/EntityClientService.java
@@ -22,10 +22,18 @@ import org.terracotta.connection.entity.Entity;
 
 
 /**
- * The specific service instance used to create client-side instances of the entities which wrap the connection to the
- * server.
+ * <p>The specific service instance used to create client-side instances of the entities which wrap the connection to the
+ * server.</p>
  * 
- * @param <T> The client-side entity type
+ * <p>A client-side entity is created in response to every successful
+ * {@link org.terracotta.connection.entity.EntityRef#fetchEntity() EntityRef.fetchEntity()} call, each of which is given
+ * a unique {@link EntityClientEndpoint}.</p>
+ * 
+ * <p>Conceptually, the endpoint can be considered much like a file descriptor:  multiple attempts to open the same
+ * file (or fetch the same entity) result in multiple unique descriptors which must be closed, independently, when no
+ * longer required.</p>
+ * 
+ * @param <T> The client-side {@link Entity} type
  * @param <C> The configuration type
  * @param <M> An {@link EntityMessage}
  * @param <R> An {@link EntityResponse}
@@ -40,34 +48,41 @@ public interface EntityClientService<T extends Entity, C, M extends EntityMessag
   boolean handlesEntityType(Class<T> cls);
 
   /**
-   * Serialize the configuration for this entity type out to a byte array
+   * Serialize the configuration for this entity type out to a byte array.
    * 
-   * @param configuration configuration to be serialized
-   * @return serialized config
+   * @param configuration Configuration object to be serialized
+   * @return Serialized configuration object
    */
   byte[] serializeConfiguration(C configuration);
 
   /**
-   * Deserialize a configuration from bytes
+   * Deserialize a configuration from bytes.
    *
-   * @param configuration bytes to be deserialized
-   * @return deserialized config
+   * @param configuration Bytes to be deserialized
+   * @return Deserialized configuration object
    */
   C deserializeConfiguration(byte[] configuration);
-  
+
   /**
-   * Create an entity of the given type.
+   * <p>Create an entity of the given type to be built over the given {@link EntityClientEndpoint}.</p>
+   * 
+   * <p>Note that the given endpoint is unique to this instance (calling
+   * {@link org.terracotta.connection.entity.EntityRef#fetchEntity() EntityRef.fetchEntity()} multiple times will result
+   * in multiple calls to this method, each with a unique endpoint instance).<p>
+   * 
+   * <p>The given endpoint is "owned by" the object this method returns.  When
+   * {@link org.terracotta.connection.entity.Entity#close()} is called, it is expected to also close this endpoint.</p>
    *
-   * @param endpoint RPC endpoint for the entity
-   * @return entity
+   * @param endpoint The RPC endpoint for interacting with the server-side entity represented by the returned instance.
+   * @return The client-side representation of the fetched server entity.
    */
   T create(EntityClientEndpoint<M, R> endpoint);
 
   /**
    * Gets the message codec which will be used to convert high-level {@link EntityMessage}/{@link EntityResponse}
-   * to byte[] and vice-versa
+   * to byte[] and vice-versa.
    *
-   * @return A {@link org.terracotta.entity.MessageCodec<M, R>}
+   * @return The {@link org.terracotta.entity.MessageCodec MessageCodec} for this entity type
    */
   MessageCodec<M, R> getMessageCodec();
 }


### PR DESCRIPTION
-this is purely a documentation change to describe more of the interactions between Entity and EntityClientEndpoint via the user-provided EntityClientService