### PR TITLE
Fix #202: Added userData argument to EntityClientService.create, from fetchEntity()

### DIFF
--- a/connection-api/src/main/java/org/terracotta/connection/Connection.java
+++ b/connection-api/src/main/java/org/terracotta/connection/Connection.java
@@ -38,8 +38,9 @@ public interface Connection extends Closeable {
    * @param name name of the entity
    * @param <T> entity type
    * @param <C> configuration type
+   * @param <U> user data type for EntityClientService
    * @return reference to the entity
    * @throws EntityNotProvidedException There is no client-side service providing entities of type T
    */
-  <T extends Entity, C> EntityRef<T, C> getEntityRef(Class<T> cls, long version, String name) throws EntityNotProvidedException;
+  <T extends Entity, C, U> EntityRef<T, C, U> getEntityRef(Class<T> cls, long version, String name) throws EntityNotProvidedException;
 }

--- a/connection-api/src/main/java/org/terracotta/connection/entity/EntityRef.java
+++ b/connection-api/src/main/java/org/terracotta/connection/entity/EntityRef.java
@@ -42,8 +42,9 @@ import org.terracotta.exception.PermanentEntityException;
  *
  * @param <T> The entity type underlying this reference.
  * @param <C> The configuration type to use when creating this entity.
+ * @param <U> User-data type to be passed to the {@link #fetchEntity()}.
  */
-public interface EntityRef<T extends Entity, C> {
+public interface EntityRef<T extends Entity, C, U> {
   /**
    * Creates the entity with the given configuration.
    * <P>
@@ -105,12 +106,13 @@ public interface EntityRef<T extends Entity, C> {
    *   release this hold on the server-side instance. Otherwise, attempts to {@link #destroy()} it will fail.
    * </P>
    *
+   * @param userData Additional constructor argument(s) to be passed to EntityClientService.
    * @return The client-side entity attached to the server-side instance
    *
    * @throws EntityNotFoundException No entity with this type and name could be found
    * @throws EntityVersionMismatchException The client and server providing services for T don't have the same version numbers
    */
-  T fetchEntity() throws EntityNotFoundException, EntityVersionMismatchException;
+  T fetchEntity(U userData) throws EntityNotFoundException, EntityVersionMismatchException;
 
   /**
    * Gets the name of the entity

--- a/entity-client-api/src/main/java/org/terracotta/entity/EntityClientService.java
+++ b/entity-client-api/src/main/java/org/terracotta/entity/EntityClientService.java
@@ -37,8 +37,9 @@ import org.terracotta.connection.entity.Entity;
  * @param <C> The configuration type
  * @param <M> An {@link EntityMessage}
  * @param <R> An {@link EntityResponse}
+ * @param <U> User data type to be passed to the {@link #create(EntityClientEndpoint)}
  */
-public interface EntityClientService<T extends Entity, C, M extends EntityMessage, R extends EntityResponse> {
+public interface EntityClientService<T extends Entity, C, M extends EntityMessage, R extends EntityResponse, U> {
   /**
    * Check if this service handles the given entity type.
    *
@@ -74,9 +75,10 @@ public interface EntityClientService<T extends Entity, C, M extends EntityMessag
    * {@link org.terracotta.connection.entity.Entity#close()} is called, it is expected to also close this endpoint.</p>
    *
    * @param endpoint The RPC endpoint for interacting with the server-side entity represented by the returned instance.
+   * @param userData Constructor argument(s) passed through from the fetchEntity().
    * @return The client-side representation of the fetched server entity.
    */
-  T create(EntityClientEndpoint<M, R> endpoint);
+  T create(EntityClientEndpoint<M, R> endpoint, U userData);
 
   /**
    * Gets the message codec which will be used to convert high-level {@link EntityMessage}/{@link EntityResponse}


### PR DESCRIPTION
DO NOT MERGE:  Currently posted to check that this makes sense to everyone - release will be required, after merge, to unblock downstream PRs which depend on this.