### PR TITLE
Issue 510: Retirement Handles for explicit retirement

### DIFF
--- a/standard-cluster-services/src/main/java/org/terracotta/entity/ExplicitRetirementHandle.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/entity/ExplicitRetirementHandle.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.entity;
+
+import java.util.concurrent.TimeUnit;
+
+public interface ExplicitRetirementHandle {
+  String getTag();
+
+  void release() throws MessageCodecException;
+
+}

--- a/standard-cluster-services/src/main/java/org/terracotta/entity/IEntityMessenger.java
+++ b/standard-cluster-services/src/main/java/org/terracotta/entity/IEntityMessenger.java
@@ -39,6 +39,18 @@ public interface IEntityMessenger {
   void messageSelf(EntityMessage message) throws MessageCodecException;
 
   /**
+   * Defer a message based on another message, which will be sent in the future.
+   *
+   * @param tag String reason tag, mainly for debugging.
+   * @param originalMessageToDefer original message to defer
+   * @param futureMessage message to use to complete original message
+   * @return handle used to release the deferred message
+   */
+  ExplicitRetirementHandle deferRetirement(String tag,
+                                           EntityMessage originalMessageToDefer,
+                                           EntityMessage futureMessage);
+
+  /**
    * Asynchronously send a message to the entity instance which looked up the service instance but also blocks the final
    * retirement acknowledgement of originalMessageToDefer until newMessageToSchedule completes.
    * 


### PR DESCRIPTION
Add retirement handles and explicit deferment/retirement to
IEntityMessenger. This is done by deferring retirement of one
message based on another, but not delivering the future message
yet. The returned handle will deliver the future message on it's
release.