### PR TITLE
[DONT MERGE] Proposal for HA/Message Tracking changes

### DIFF
--- a/entity-server-api/src/main/java/org/terracotta/entity/ActiveServerEntity.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/ActiveServerEntity.java
@@ -52,11 +52,17 @@ public interface ActiveServerEntity<M extends EntityMessage, R extends EntityRes
    *  called concurrently with other invokes.</p>
    *
    * @param clientDescriptor source instance from which the invocation originates.
-   * @param message The message from the client
+   * @param currentOrderedId current id for this client that this invoke is part of
+   * @param eldestOrderedId earliest active id for this client; id's older than this
+   * can be thrown away.
+   * @param message The message from a client
    * @return possible return value
    */
-  R invoke(ClientDescriptor clientDescriptor, M message) throws EntityUserException;
-  
+  R invokeActive(ClientDescriptor clientDescriptor,
+           long currentOrderedId,
+           long eldestOrderedId,
+           M message) throws EntityUserException;
+
   /**
    * <p>Called when an entity was loaded from some persistent state and the entity is expected to already be known to the
    *  server.</p>

--- a/entity-server-api/src/main/java/org/terracotta/entity/CommonServerEntity.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/CommonServerEntity.java
@@ -46,4 +46,5 @@ public interface CommonServerEntity<M extends EntityMessage, R extends EntityRes
    *  respect to all other messages enqueued for the entity.</p>
    */
   void destroy();
+
 }

--- a/entity-server-api/src/main/java/org/terracotta/entity/PassiveServerEntity.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/PassiveServerEntity.java
@@ -36,9 +36,16 @@ public interface PassiveServerEntity<M extends EntityMessage, R extends EntityRe
    *  under a given key, the messages it creates and sends for synchronization will be executed in that key, on the passive,
    *  via this invoke() entry-point.</p>
    *
+   * @param clientDescriptor source instance from which the invocation originates.
+   * @param currentOrderedId current id for this client that this invoke is part of
+   * @param eldestOrderedId earliest active id for this client; id's older than this
+   * can be thrown away.
    * @param message The message from a client or upstream active server
    */
-  void invoke(M message) throws EntityUserException;
+  void invokePassive(ClientDescriptor clientDescriptor,
+              long currentOrderedId,
+              long eldestOrderedId,
+              M message) throws EntityUserException;
 
   /**
    * <p>Called on {@link ConcurrencyStrategy#MANAGEMENT_KEY} to notify the receiver that it is about to start receiving
@@ -69,4 +76,12 @@ public interface PassiveServerEntity<M extends EntityMessage, R extends EntityRe
    *  where this call is executed.</p>
    */
   void endSyncConcurrencyKey(int concurrencyKey);
+  
+  /**
+   * Notify an entity that a particular client disconnected from the active.
+   *
+   * @param client client
+   */
+  void notifyClientDisconnectedFromActive(ClientDescriptor client);
+
 }


### PR DESCRIPTION
We have mostly decided on, for each invoke (active or passive) passing in the ClientDescriptor (active already did this) and the current and eldest message id. The current is used to track the invoke within the Client, the eldest is used for garbage collection.

Additionally, a new method is added to CommonServerEntity, which notifies at points where the client
view of the data is in synch with the servers. In particular, this would be used when a client disconnects, or when client reconnect happens. At both of these points all historical information related to the client can be thrown away. 