### PR TITLE
Issue237: add Serializable to ClientDescriptor

### DIFF
--- a/entity-server-api/src/main/java/org/terracotta/entity/ClientDescriptor.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/ClientDescriptor.java
@@ -18,11 +18,15 @@
  */
 package org.terracotta.entity;
 
+import java.io.Serializable;
+
 /**
  * An opaque token representing a specific entity instance on a specific client node.
- * This is used by server-side code to specifically communicate with or track connection status of a specific client-side
- * object instance.
+ * This is used by server-side code to specifically communicate with or track connection
+ * status of a specific client-side object instance. This is used both in actives
+ * and passives in certain cases.
  * Note that implementations are expected to provide a proper equals()/hashCode().
  */
-public interface ClientDescriptor {
+public interface ClientDescriptor extends Serializable {
+
 }

--- a/entity-server-api/src/main/java/org/terracotta/entity/InvokeContext.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/InvokeContext.java
@@ -22,4 +22,11 @@ public interface InvokeContext {
    * @return txid, or -1 if unknown.
    */
   long getOldestTransactionId();
+
+  /**
+   * Does the client information (ClientDescriptor and transaction ids)
+   * represent an actual valid client endpoint information or is it merely a marker.
+   * @return true if the client information represents a real client.
+   */
+  boolean isValidClientInformation();
 }


### PR DESCRIPTION
Adds serializable, and isValid(), to ClientDescriptor. Active server services trying to use the message tracking may need to pass ClientDescriptors to passives, so Serializable seems necessary. 

isValid() is merely to represent the fact there exists a NULL implementation that means nothing, seems useful in order to ignore client descriptors that are ersatz. 