### PR TITLE
APIS-266: Add concurrency key to InvokeContext (Release/1.3)

### DIFF
--- a/entity-server-api/src/main/java/org/terracotta/entity/InvokeContext.java
+++ b/entity-server-api/src/main/java/org/terracotta/entity/InvokeContext.java
@@ -53,4 +53,10 @@ public interface InvokeContext {
    * @return
    */
   ClientSourceId makeClientSourceId(long opaque);
+
+  /**
+   * Return the concurrency key pertaining to this invoke.
+   * @return concurrency key of invoke. 
+   */
+  int getConcurrencyKey();
 }


### PR DESCRIPTION
There is a need for the invoke context to make the
concurency key available on each invoke.

Release 1.3 version.