### PR TITLE
Remove snapshots

### DIFF
--- a/connection-api/pom.xml
+++ b/connection-api/pom.xml
@@ -31,32 +31,11 @@
   <artifactId>connection-api</artifactId>
 
   <properties>
-    <asciidoctor.version>1.5.2</asciidoctor.version>
+    <asciidoctor.version>2.2.2</asciidoctor.version>
     <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
-    <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>coderay</artifactId>
-      <version>1.1.0</version>
-      <type>gem</type>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -64,28 +43,10 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-    
+
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>1.0.5</version>
-        <configuration>
-          <!-- align JRuby version with AsciidoctorJ to avoid redundant downloading -->
-          <jrubyVersion>1.7.9</jrubyVersion>
-          <gemHome>${project.build.directory}/gems</gemHome>
-          <gemPath>${project.build.directory}/gems</gemPath>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>initialize</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>        
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.8</version>
@@ -113,7 +74,6 @@
               <goal>process-asciidoc</goal>
             </goals>
             <configuration>
-              <sourceHighlighter>coderay</sourceHighlighter>
               <preserveDirectories>true</preserveDirectories>
               <backend>html5</backend>
               <attributes>
@@ -121,6 +81,7 @@
                 <sectanchors>true</sectanchors>
                 <toclevels>3</toclevels>
                 <linkattrs>true</linkattrs>
+                <source-highlighter>coderay</source-highlighter>
               </attributes>
               <gemPath>${project.build.directory}/gems-provided</gemPath>
               <requires>

--- a/connection-api/src/main/asciidoc/index.adoc
+++ b/connection-api/src/main/asciidoc/index.adoc
@@ -41,18 +41,6 @@ include::{sourcedir}/org/terracotta/connection/BasicConnectTest.java[tags=using]
 include::{sourcedir}/org/terracotta/connection/BasicConnectTest.java[tags=destroy]
 ----
 
-== Handling Connection Loss (Rejoin)
-
-For simplicity’s sake, the platform will not attempt to clear its state and
-rejoin transparently. Applications built on top of the platform will need to
-figure out what they want to do. To that end on creating the connection, there
-will be an option to register a DisconnectHandler like so.
-
-[source,java,indent=0]
-----
-include::{sourcedir}/org/terracotta/connection/BasicConnectTest.java[tags=handleConnectionLoss]
-----
-
 == API Reference
 
 link:./apidocs/index.html[Overview]
@@ -61,9 +49,6 @@ link:./apidocs/org/terracotta/connection/Connection.html[org.terracotta.connecti
 link:./apidocs/org/terracotta/connection/ConnectionException.html[org.terracotta.connection.ConnectionException] +
 link:./apidocs/org/terracotta/connection/ConnectionFactory.html[org.terracotta.connection.ConnectionFactory] +
 link:./apidocs/org/terracotta/connection/ConnectionService.html[org.terracotta.connection.ConnectionService] +
-link:./apidocs/org/terracotta/connection/DisconnectHandler.html[org.terracotta.connection.DisconnectHandler] +
 
-link:./apidocs/org/terracotta/connection/entity/ConfigurationMismatchException.html[org.terracotta.connection.entity.ConfigurationMismatchException] +
 link:./apidocs/org/terracotta/connection/entity/Entity.html[org.terracotta.connection.entity.Entity] +
-link:./apidocs/org/terracotta/connection/entity/EntityMaintenanceRef.html[org.terracotta.connection.entity.EntityMaintenanceRef] +
 link:./apidocs/org/terracotta/connection/entity/EntityRef.html[org.terracotta.connection.entity.EntityRef] +

--- a/connection-api/src/test/java/org/terracotta/connection/BasicConnectTest.java
+++ b/connection-api/src/test/java/org/terracotta/connection/BasicConnectTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2011-2018 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
+ * Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG.
+ */
+
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Connection API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.connection;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.terracotta.connection.entity.Entity;
+import org.terracotta.connection.entity.EntityRef;
+import org.terracotta.exception.EntityException;
+
+
+public class BasicConnectTest {
+  public Connection getConnection() throws ConnectionException, URISyntaxException {
+    // tag::connect[]
+    Properties properties = new Properties();
+    URI uri = new URI("terracotta://localhost:1234");
+
+    Connection connection = ConnectionFactory.connect(uri, properties);
+    // end::connect[]
+
+    return connection;
+  }
+
+  @Test
+  @Ignore
+  public void testCreate() throws ConnectionException, URISyntaxException, EntityException {
+    Connection connection = getConnection();
+
+    // tag::create[]
+    // Get a reference on the entity name
+    EntityRef<Example, ExampleConfiguration, Object> ref = connection.getEntityRef(Example.class, Example.VERSION, "foo");
+    ExampleConfiguration configuration = new ExampleConfiguration();
+    // Create it
+    ref.create(configuration);
+    // end::create[]
+  }
+
+  @Test
+  @Ignore
+  public void testUsing() throws ConnectionException, URISyntaxException, EntityException {
+    Connection connection = getConnection();
+
+    // tag::using[]
+    // Get the entity, this locks out someone attempting to enter maintenance
+    // mode, it’s blocked by an existing maintenance mode hold.
+    EntityRef<Example, ExampleConfiguration, Object> entityRef = connection.getEntityRef(Example.class, Example.VERSION, "foo");
+    Example e = entityRef.fetchEntity(new Object());
+    // do some stuff
+    e.doStuff();
+    // Close.
+    e.close();
+    // end::using[]
+  }
+
+  @Test
+  @Ignore
+  public void testDestroy() throws ConnectionException, URISyntaxException, EntityException {
+    Connection connection = getConnection();
+    EntityRef<Example, ExampleConfiguration, Object> ref = connection.getEntityRef(Example.class, Example.VERSION, "foo");
+
+    // tag::destroy[]
+    // See if we can destroy the entity.
+    ref.destroy();
+    // end::destroy[]
+  }
+
+  interface Example extends Entity {
+    public static final long VERSION = 1;
+
+    void doSomeMaintenance();
+
+    void doSomeNonMaintenanceStuff();
+
+    void doSomethingElse();
+
+    void doStuff();
+  }
+
+  static class ExampleConfiguration {
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,9 @@
 
   <repositories>
     <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
       <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
+      <url>https://repo.terracotta.org/maven2</url>
+      <snapshots><enabled>false</enabled></snapshots>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This commit stream includes:

* Recover BasicConnectTest and update connection-api documentation

  This commit

  * recovers the BasicConnectTest class (used for documentation samples)
  * updates Asciidoctor plug-in (dropping need for rubygems:coderay)
  * make adjustments to documentation to update for changes over time

* Remove POM repositories elements

  This commit reduces the repositories and pluginRepositories elements
  to those required to locate the direct dependencies of this project.
  More specifically, the SNAPSHOT repositories are removed -- inclusion
  of SNAPSHOT repositories interferes with the use of range-based version
  specifications.  Should a developer want to include a SNAPSHOT release
  in a build, local addition of the SNAPSHOT repositories can be employed.